### PR TITLE
Use diagnostics' severity to log their message using the corresponding log level

### DIFF
--- a/src/databricks/labs/lakebridge/cli.py
+++ b/src/databricks/labs/lakebridge/cli.py
@@ -40,7 +40,6 @@ from databricks.labs.lakebridge.transpiler.lsp.lsp_engine import LSPConfig
 from databricks.labs.lakebridge.transpiler.sqlglot.sqlglot_engine import SqlglotEngine
 from databricks.labs.lakebridge.transpiler.transpile_engine import TranspileEngine
 
-from src.databricks.labs.lakebridge.transpiler.transpile_status import ErrorSeverity
 
 lakebridge = App(__file__)
 logger = get_logger(__file__)

--- a/src/databricks/labs/lakebridge/cli.py
+++ b/src/databricks/labs/lakebridge/cli.py
@@ -1,6 +1,7 @@
 import asyncio
 import dataclasses
 import json
+import logging
 import os
 import time
 from pathlib import Path
@@ -306,14 +307,10 @@ async def _transpile(ctx: ApplicationContext, config: TranspileConfig, engine: T
     logger.debug(f"User: {user}")
     _override_workspace_client_config(ctx, config.sdk_config)
     status, errors = await do_transpile(ctx.workspace_client, engine, config)
+    levels = {"ERROR": logging.ERROR, "WARNING": logging.WARNING, "INFO": logging.INFO}
     for error in errors:
-        msg = f"{error.path}: {error.message}"
-        if error.severity.name == "ERROR":
-            logger.error(msg)
-        elif error.severity.name == "WARNING":
-            logger.warning(msg)
-        elif error.severity.name == "INFO":
-            logger.info(msg)
+        level = levels.get(error.severity.name, logging.DEBUG)
+        logger.log(level, f"{error.path}: {error.message}")
 
     # Table Template in labs.yml requires the status to be list of dicts Do not change this
     logger.info(f"lakebridge Transpiler encountered {len(status)} from given {config.input_source} files.")

--- a/src/databricks/labs/lakebridge/cli.py
+++ b/src/databricks/labs/lakebridge/cli.py
@@ -40,6 +40,7 @@ from databricks.labs.lakebridge.transpiler.lsp.lsp_engine import LSPConfig
 from databricks.labs.lakebridge.transpiler.sqlglot.sqlglot_engine import SqlglotEngine
 from databricks.labs.lakebridge.transpiler.transpile_engine import TranspileEngine
 
+from src.databricks.labs.lakebridge.transpiler.transpile_status import ErrorSeverity
 
 lakebridge = App(__file__)
 logger = get_logger(__file__)
@@ -307,7 +308,13 @@ async def _transpile(ctx: ApplicationContext, config: TranspileConfig, engine: T
     _override_workspace_client_config(ctx, config.sdk_config)
     status, errors = await do_transpile(ctx.workspace_client, engine, config)
     for error in errors:
-        logger.error(f"Error Transpiling: {str(error)}")
+        msg = f"{error.path}: {error.message}"
+        if error.severity.name == "ERROR":
+            logger.error(msg)
+        elif error.severity.name == "WARNING":
+            logger.warning(msg)
+        elif error.severity.name == "INFO":
+            logger.info(msg)
 
     # Table Template in labs.yml requires the status to be list of dicts Do not change this
     logger.info(f"lakebridge Transpiler encountered {len(status)} from given {config.input_source} files.")

--- a/tests/unit/test_cli_transpile.py
+++ b/tests/unit/test_cli_transpile.py
@@ -363,5 +363,5 @@ def test_transpile_prints_errors(caplog, tmp_path, mock_workspace_client):
             error_file_path=error_file_path,
         )
 
-    assert any("TranspileError" in record.message for record in caplog.records)
+    assert any(str(input_source) in record.message for record in caplog.records)
     assert any("UNSUPPORTED_LCA" in record.message for record in caplog.records)

--- a/tests/unit/test_cli_transpile.py
+++ b/tests/unit/test_cli_transpile.py
@@ -364,4 +364,4 @@ def test_transpile_prints_errors(caplog, tmp_path, mock_workspace_client):
         )
 
     assert any(str(input_source) in record.message for record in caplog.records)
-    assert any("UNSUPPORTED_LCA" in record.message for record in caplog.records)
+    assert any("LCA conversion not supported" in record.message for record in caplog.records)


### PR DESCRIPTION
## Changes
### What does this PR do?

This avoids reporting warning as errors to the console.

### Functionality

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs lakebridge ...`
- [ ] ... +add your own

### Tests

- [x] manually tested
- [ ] added unit tests
- [ ] added integration tests
