### PR TITLE
Fix issue templates, so issues can be created.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -4,7 +4,7 @@ name: Bug Report
 description: Something is not working in Lakebridge
 title: "[BUG]: "
 labels: ["needs-triage"]
-type: ["bug"]
+type: "bug"
 
 body:
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -4,7 +4,7 @@ name: Feature Request
 description: Something new needs to happen with Lakebridge
 title: "[FEATURE]: "
 labels: ["needs-triage"]
-type: ["feature"]
+type: "feature"
 
 body:
   - type: checkboxes


### PR DESCRIPTION
## Changes
### What does this PR do?

There's a schema-issue with the issue templates for this project, which prevents them from loading. This means that issues can't be created.

### Relevant implementation details

Refer: [Top-level syntax](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms#top-level-syntax) for GitHub forms.