### PR TITLE
Documentation markdown improvements

### DIFF
--- a/docs/lakebridge/docs/assessment/analyzer/export_metadata.mdx
+++ b/docs/lakebridge/docs/assessment/analyzer/export_metadata.mdx
@@ -10,24 +10,24 @@ All the major ETL platforms provide some kind of export of their code repositori
 
 ## PowerCenter
 
-* **Overview**
-To run the BladeBridge analyzer or converters on Informatica XMLs, the XML file first need to be extracted out of the PowerCenter repository. Typically, it is easier to deal with the analysis and conversion of a relatively granular level, so extracting the artifacts at the workflow level is advisable.  Objects can be exported from Powercenter Repository Manager or using *pmrep* command
+* **Overview**<br/>
+  To run the BladeBridge analyzer or converters on Informatica XMLs, the XML file first need to be extracted out of the PowerCenter repository. Typically, it is easier to deal with the analysis and conversion of a relatively granular level, so extracting the artifacts at the workflow level is advisable.  Objects can be exported from Powercenter Repository Manager or using *pmrep* command
 
-* **Metadata Extraction**
-To extract the metadata out of PowerCenter repository, use the following commands:
+* **Metadata Extraction**<br/>
+  To extract the metadata out of PowerCenter repository, use the following commands:
 
-* **Connect to repository**
+* **Connect to repository**<br/>
 `pmrep connect <list of credentials>`
 
-* **Get the list of folders**
+* **Get the list of folders**<br/>
 `pmrep listobjects -o FOLDER`
 
-* **For each folder, get the list of workflows**
+* **For each folder, get the list of workflows**<br/>
 `pmrep listobjects -o WORKFLOW -f <your folder name>`
 
-* **Workflow extraction**
-Create a batch script with the following command template for each folder.
-Note: Excel can be used to create the script with the following command.
+* **Workflow extraction**<br/>
+  Create a batch script with the following command template for each folder.
+  Note: Excel can be used to create the script with the following command:
 `pmrep objectexport -n workflow_name -o WORKFLOW -f folder_name -b -r -m -s -u path-to-output-file`
 
 ## DataStage

--- a/docs/lakebridge/docs/assessment/analyzer/export_metadata.mdx
+++ b/docs/lakebridge/docs/assessment/analyzer/export_metadata.mdx
@@ -17,51 +17,63 @@ All the major ETL platforms provide some kind of export of their code repositori
   To extract the metadata out of PowerCenter repository, use the following commands:
 
 * **Connect to repository**<br/>
-`pmrep connect <list of credentials>`
+  ```
+  pmrep connect <list of credentials>
+  ```
 
 * **Get the list of folders**<br/>
-`pmrep listobjects -o FOLDER`
+  ```
+  pmrep listobjects -o FOLDER
+  ```
 
 * **For each folder, get the list of workflows**<br/>
-`pmrep listobjects -o WORKFLOW -f <your folder name>`
+  ```
+  pmrep listobjects -o WORKFLOW -f <your folder name>
+  ```
 
 * **Workflow extraction**<br/>
   Create a batch script with the following command template for each folder.
+
   Note: Excel can be used to create the script with the following command:
-`pmrep objectexport -n workflow_name -o WORKFLOW -f folder_name -b -r -m -s -u path-to-output-file`
+  ```
+  pmrep objectexport -n workflow_name -o WORKFLOW -f folder_name -b -r -m -s -u path-to-output-file
+  ```
 
 ## DataStage
 
 * Typically in DataStage the easiest way to export the objects is by using the GUI.  However, Datastage has command line utilities to export via CLI.
 * Please use the XML format, as both  Analyzer and Converter support XML-only Datastage exports
 
-
 ## SSIS
 
-* You’ll need to export the DTSX packages. For details on how to obtain it see: https://docs.microsoft.com/en-us/sql/integration-services/import-export-data/save-and-run-package-sql-server-import-and-export-wizard?view=sql-server-ver15  
-In many cases the DTSX packages can also be just copied to the analyzer folder
+You’ll need to export the DTSX packages. For details on how to obtain it see: https://docs.microsoft.com/en-us/sql/integration-services/import-export-data/save-and-run-package-sql-server-import-and-export-wizard?view=sql-server-ver15
+
+In many cases the DTSX packages can also be just copied to the analyzer folder.
 
 ## Talend
 
-* To export all jobs in bulk, right click on Job Designs and select "Export Items".  In the popup, select "Include All Dependencies"
+To export all jobs in bulk, right click on Job Designs and select "Export Items".  In the popup, select "Include All Dependencies"
 <img src={useBaseUrl('img/talend-metadata-extract.png')} alt="talend-export" />
+
 Note: while Talend jobs can be exported as a single zip file, when running analyzer or any converter utilities please unzip the file(s).  Both the analyzer and converters will look for .item and .properties files in non-zipped folders.
 
 ## ODI
 
-* Exporting jobs in ODI is detailed in this document: https://docs.oracle.com/middleware/1212/odi/ODIDG/export_import.htm#ODIDG578
+Exporting jobs in ODI is detailed in this document: https://docs.oracle.com/middleware/1212/odi/ODIDG/export_import.htm#ODIDG578
 
 ## Alteryx
 
-* Analyzer needs the .yxmd files. These can be obtained by Select File > Export to download your workflow to your local machine in .yxmd format.
+Analyzer needs the .yxmd files. These can be obtained by Select File > Export to download your workflow to your local machine in .yxmd format.
 
 ## SAP Business Objects Data Services
 
-* Instructions for export can be found in the following articles: https://help.sap.com/viewer/2d2abbb0fab34071a4c53b7de873241b/4.2.13/en-US/571901366d6d1014b3fc9283b0e91070.html https://help.sap.com/viewer/2d2abbb0fab34071a4c53b7de873241b/4.2.13/en-US/5718d4ba6d6d1014b3fc9283b0e91070.html
+Instructions for export can be found in the following articles: https://help.sap.com/viewer/2d2abbb0fab34071a4c53b7de873241b/4.2.13/en-US/571901366d6d1014b3fc9283b0e91070.html https://help.sap.com/viewer/2d2abbb0fab34071a4c53b7de873241b/4.2.13/en-US/5718d4ba6d6d1014b3fc9283b0e91070.html
 
 ## IICS / IDMC
 
-* Select all the Mapping Configuration tasks you want to read the metadata from and export them as a single file.
+Select all the Mapping Configuration tasks you want to read the metadata from and export them as a single file.
 <img src={useBaseUrl('img/infacloud-export1.png')} alt="infacloud-export" />
+
 Note #1: Analyzer and Converter expect the metadata from InfaCloud to be preserved as zip files.  Please do not change the content of these files.
-Note #2: InfaCloud zip files are deeply nested.  Analyzer and Converter temporarily unzip the contents of the zip files into the folder locations associated with the output analyzer report and output code respectively.  On Windows OS, please keep the paths specified in -d, -r, -o switches short, as the fully exploded path may exceed the Windows max path limitation
+
+Note #2: InfaCloud zip files are deeply nested.  Analyzer and Converter temporarily unzip the contents of the zip files into the folder locations associated with the output analyzer report and output code respectively.  On Windows OS, please keep the paths specified in `-d`, `-r`, `-o` switches short, as the fully exploded path may exceed the Windows max path limitation

--- a/docs/lakebridge/docs/assessment/analyzer/export_metadata.mdx
+++ b/docs/lakebridge/docs/assessment/analyzer/export_metadata.mdx
@@ -4,8 +4,8 @@ title: Exporting Legacy Metadata
 ---
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
-Analyzer expects all the legacy code to be exported into a folder accessible by it.  
-For SQL code exporting, most times a database export can be used to export object definitions (tables, views procedures, functions etc...) in bulk.  Ideally, each SQL file should contain a single artifact.  
+Analyzer expects all the legacy code to be exported into a folder accessible by it.<br/>
+For SQL code exporting, most times a database export can be used to export object definitions (tables, views procedures, functions etc...) in bulk.  Ideally, each SQL file should contain a single artifact.<br/>
 All the major ETL platforms provide some kind of export of their code repositories. Typically this is done into XML or JSON formats which can be used to restore the environment. Here is a short guide for how to export metadata from various platforms:
 
 ## PowerCenter

--- a/docs/lakebridge/docs/assessment/analyzer/index.mdx
+++ b/docs/lakebridge/docs/assessment/analyzer/index.mdx
@@ -48,5 +48,4 @@ Execute the below command to initialize the transpile process.
  databricks labs lakebridge analyze --source-directory <absolute-path> --report-file <absolute-path>
 ```
 
-<img src={useBaseUrl('img/lakebridge-analyzer-run.gif')} alt="transpile-run" />
-
+<img src={useBaseUrl('img/remorph-analyzer-run.gif')} alt="transpile-run" />

--- a/docs/lakebridge/docs/assessment/analyzer/index.mdx
+++ b/docs/lakebridge/docs/assessment/analyzer/index.mdx
@@ -10,14 +10,14 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 The **Lakebridge Analyzer** is built to scan and interpret metadata from ETL pipelines and SQL assets. Its analysis provides several key insights:
 
-- **Job Complexity Assessment**
-Analyzer evaluates the complexity of your ETL and SQL jobs. These metrics are fed into the **Conversion Calculator** to help estimate both software licensing costs and the engineering hours required for the migration.
+- **Job Complexity Assessment**<br/>
+  Analyzer evaluates the complexity of your ETL and SQL jobs. These metrics are fed into the **Conversion Calculator** to help estimate both software licensing costs and the engineering hours required for the migration.
 
-- **Comprehensive Job Inventory**
-It generates a full inventory of components such as mappings, programs, transformations, functions, and dynamic variables—giving you a clear picture of what exists in your legacy environment.
+- **Comprehensive Job Inventory**<br/>
+  It generates a full inventory of components such as mappings, programs, transformations, functions, and dynamic variables—giving you a clear picture of what exists in your legacy environment.
 
-- **Cross-System Interdependency Mapping**
-Analyzer identifies **interdependencies** between jobs, systems, and components — surfacing how different parts of your codebase interact. This is crucial for sequencing migration efforts, minimizing risk, and avoiding disruption during cutover planning.
+- **Cross-System Interdependency Mapping**<br/>
+  Analyzer identifies **interdependencies** between jobs, systems, and components — surfacing how different parts of your codebase interact. This is crucial for sequencing migration efforts, minimizing risk, and avoiding disruption during cutover planning.
 
 
 

--- a/docs/lakebridge/docs/overview.mdx
+++ b/docs/lakebridge/docs/overview.mdx
@@ -62,7 +62,7 @@ The table below summarizes the source platforms that we currently support:
 | SQL Server (incl. Synapse)   |  &#x2705;   |          | &#x2705; |                   |                    |
 | Teradata                     |  &#x2705;   |          | &#x2705; |                   |                    |
 
-For more information on using the transpiler, refer to the [Transpile][3].
+For more information on using the transpiler, refer to the [Transpile][3] documentation.
 
 Post-migration Reconciliation
 -----------------------------

--- a/docs/lakebridge/docs/transpile/index.mdx
+++ b/docs/lakebridge/docs/transpile/index.mdx
@@ -10,7 +10,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 ## Verify Installation
 Verify the successful installation by executing the provided command; confirmation of a successful installation is indicated when the displayed output aligns with the example screenshot provided:
 ```bash
- databricks labs remorph transpile --help
+ databricks labs lakebridge transpile --help
  ```
 <img src={useBaseUrl('img/transpile-help.png')} alt="transpile-help" />
 
@@ -31,7 +31,7 @@ Below is the detailed explanation on the arguments required for Transpile.
 ## Execution
 Execute the below command to initialize the transpile process.
 ```bash
- databricks labs remorph transpile --transpiler-config-path <absolute-path> --input-source <absolute-path> --source-dialect <snowflake> --output-folder <absolute-path> --skip-validation <True|False> --catalog-name <catalog name> --schema-name <schema name>
+ databricks labs lakebridge transpile --transpiler-config-path <absolute-path> --input-source <absolute-path> --source-dialect <snowflake> --output-folder <absolute-path> --skip-validation <True|False> --catalog-name <catalog name> --schema-name <schema name>
 ```
 
 <img src={useBaseUrl('img/transpile-run.gif')} alt="transpile-run" />


### PR DESCRIPTION
## Changes

### What does this PR do?

This PR contains addresses some cosmetic issues in the documentation. These include:

 - A typo in the _Overview_ section.
 - Formatting issues for lists in the _Assessment_ section, including line-breaks.
 - A few stray `remorph` references in example commands.
 - A broken image link. 

### Caveats/things to watch out for when reviewing:

Markdown is sensitive to trailing whitespace: two trailing space characters at the end of a line insert a line-break. These are very difficult to spot, and our repository settings try to strip trailing whitespace. As such it's better to use an explicit `<br/>` tag where a line-break is intended.

### Functionality

- updated user documentation

### Tests

- manually reviewed
