### PR TITLE
Make error reporting more compact

### DIFF
--- a/src/databricks/labs/lakebridge/cli.py
+++ b/src/databricks/labs/lakebridge/cli.py
@@ -1,5 +1,6 @@
 import asyncio
 import dataclasses
+import itertools
 import json
 import logging
 import os
@@ -41,6 +42,7 @@ from databricks.labs.lakebridge.transpiler.lsp.lsp_engine import LSPConfig
 from databricks.labs.lakebridge.transpiler.sqlglot.sqlglot_engine import SqlglotEngine
 from databricks.labs.lakebridge.transpiler.transpile_engine import TranspileEngine
 
+from src.databricks.labs.lakebridge.transpiler.transpile_status import ErrorSeverity
 
 lakebridge = App(__file__)
 logger = get_logger(__file__)
@@ -307,10 +309,21 @@ async def _transpile(ctx: ApplicationContext, config: TranspileConfig, engine: T
     logger.debug(f"User: {user}")
     _override_workspace_client_config(ctx, config.sdk_config)
     status, errors = await do_transpile(ctx.workspace_client, engine, config)
-    levels = {"ERROR": logging.ERROR, "WARNING": logging.WARNING, "INFO": logging.INFO}
-    for error in errors:
-        level = levels.get(error.severity.name, logging.DEBUG)
-        logger.log(level, f"{error.path}: {error.message}")
+    for path, errors in itertools.groupby(errors, key= lambda x: x.path):
+        errs = list(errors)
+        errors_by_severity = {severity.name:len(list(errors)) for severity, errors in itertools.groupby(errs, key= lambda x: x.severity)}
+        reports = []
+        for severity in [ErrorSeverity.ERROR, ErrorSeverity.WARNING]:
+            if severity.name in errors_by_severity:
+                word = str.lower(severity.name) + "s" if errors_by_severity[severity.name] > 1 else ""
+                reports.append(f"{errors_by_severity[severity.name]} {word}")
+
+        msg = ", ".join(reports) + " found"
+
+        if ErrorSeverity.ERROR.name in errors_by_severity:
+            logger.error(f"{path}: {msg}")
+        elif ErrorSeverity.WARNING.name in errors_by_severity:
+            logger.warning(f"{path}: {msg}")
 
     # Table Template in labs.yml requires the status to be list of dicts Do not change this
     logger.info(f"lakebridge Transpiler encountered {len(status)} from given {config.input_source} files.")

--- a/src/databricks/labs/lakebridge/cli.py
+++ b/src/databricks/labs/lakebridge/cli.py
@@ -40,7 +40,6 @@ from databricks.labs.lakebridge.transpiler.lsp.lsp_engine import LSPConfig
 from databricks.labs.lakebridge.transpiler.sqlglot.sqlglot_engine import SqlglotEngine
 from databricks.labs.lakebridge.transpiler.transpile_engine import TranspileEngine
 
-from src.databricks.labs.lakebridge.transpiler.transpile_status import ErrorSeverity
 
 lakebridge = App(__file__)
 logger = get_logger(__file__)

--- a/src/databricks/labs/lakebridge/cli.py
+++ b/src/databricks/labs/lakebridge/cli.py
@@ -2,7 +2,6 @@ import asyncio
 import dataclasses
 import itertools
 import json
-import logging
 import os
 import time
 from pathlib import Path
@@ -309,9 +308,11 @@ async def _transpile(ctx: ApplicationContext, config: TranspileConfig, engine: T
     logger.debug(f"User: {user}")
     _override_workspace_client_config(ctx, config.sdk_config)
     status, errors = await do_transpile(ctx.workspace_client, engine, config)
-    for path, errors in itertools.groupby(errors, key= lambda x: x.path):
+    for path, errors in itertools.groupby(errors, key=lambda x: x.path):
         errs = list(errors)
-        errors_by_severity = {severity.name:len(list(errors)) for severity, errors in itertools.groupby(errs, key= lambda x: x.severity)}
+        errors_by_severity = {
+            severity.name: len(list(errors)) for severity, errors in itertools.groupby(errs, key=lambda x: x.severity)
+        }
         reports = []
         for severity in [ErrorSeverity.ERROR, ErrorSeverity.WARNING]:
             if severity.name in errors_by_severity:

--- a/src/databricks/labs/lakebridge/cli.py
+++ b/src/databricks/labs/lakebridge/cli.py
@@ -1,6 +1,7 @@
 import asyncio
 import dataclasses
 import json
+import logging
 import os
 import time
 from pathlib import Path
@@ -306,14 +307,10 @@ async def _transpile(ctx: ApplicationContext, config: TranspileConfig, engine: T
     logger.debug(f"User: {user}")
     _override_workspace_client_config(ctx, config.sdk_config)
     status, errors = await do_transpile(ctx.workspace_client, engine, config)
+    levels = {"ERROR": logging.ERROR, "WARNING": logging.WARNING, "INFO": logging.INFO}
     for error in errors:
-        msg = f"{error.path}: {error.message}"
-        if error.severity.name == "ERROR":
-            logger.error(msg)
-        elif error.severity.name == "WARNING":
-            logger.warning(msg)
-        elif error.severity.name == "INFO":
-            logger.info(msg)
+        level = levels.get(error.severity.name, logging.DEBUG)
+        logger.log(level, f"{error.path}: {error.message}")
 
     # Table Template in labs.yml requires the status to be list of dicts Do not change this
     logger.info(f"lakebridge Transpiler encountered {len(status)} from given {config.input_source} files.")

--- a/src/databricks/labs/lakebridge/cli.py
+++ b/src/databricks/labs/lakebridge/cli.py
@@ -40,6 +40,7 @@ from databricks.labs.lakebridge.transpiler.lsp.lsp_engine import LSPConfig
 from databricks.labs.lakebridge.transpiler.sqlglot.sqlglot_engine import SqlglotEngine
 from databricks.labs.lakebridge.transpiler.transpile_engine import TranspileEngine
 
+from src.databricks.labs.lakebridge.transpiler.transpile_status import ErrorSeverity
 
 lakebridge = App(__file__)
 logger = get_logger(__file__)
@@ -307,7 +308,13 @@ async def _transpile(ctx: ApplicationContext, config: TranspileConfig, engine: T
     _override_workspace_client_config(ctx, config.sdk_config)
     status, errors = await do_transpile(ctx.workspace_client, engine, config)
     for error in errors:
-        logger.error(f"Error Transpiling: {str(error)}")
+        msg = f"{error.path}: {error.message}"
+        if error.severity.name == "ERROR":
+            logger.error(msg)
+        elif error.severity.name == "WARNING":
+            logger.warning(msg)
+        elif error.severity.name == "INFO":
+            logger.info(msg)
 
     # Table Template in labs.yml requires the status to be list of dicts Do not change this
     logger.info(f"lakebridge Transpiler encountered {len(status)} from given {config.input_source} files.")

--- a/src/databricks/labs/lakebridge/transpiler/execute.py
+++ b/src/databricks/labs/lakebridge/transpiler/execute.py
@@ -159,38 +159,33 @@ def _process_single_result(context: TranspilingContext, error_list: list[Transpi
 
     output_path = cast(Path, context.output_path)
     with output_path.open("w") as w:
-        w.write(_make_header(context.input_path, error_list))
+        w.write(make_header(context.input_path, error_list))
         w.write(output_code)
 
     logger.info(f"Processed file: {context.input_path} (errors: {len(error_list)})")
 
 
-def _make_header(file_path: Path, errors: list[TranspileError]) -> str:
+def make_header(file_path: Path, errors: list[TranspileError]) -> str:
     header = ""
     failed_producing_output = False
-    diag_by_severity = {}
+    diag_by_severity = {
+        severity.name: list(diags) for severity, diags in itertools.groupby(errors, key=lambda x: x.severity)
+    }
     line_numbers = {}
 
-    for severity, diags in itertools.groupby(errors, key=lambda x: x.severity):
-        diag_by_severity[severity] = list(diags)
-
-    if ErrorSeverity.ERROR in diag_by_severity:
+    if ErrorSeverity.ERROR.name in diag_by_severity:
         header += f"/*\n    Failed transpilation of {file_path}\n"
         header += "\n    The following errors were found while transpiling:\n"
-        for diag in diag_by_severity[ErrorSeverity.ERROR]:
-            if diag.range:
-                line_numbers[diag.range.start.line] = 0
-            header += _append_diagnostic(diag)
-            failed_producing_output = failed_producing_output or diag.kind == ErrorKind.PARSING
+        header += _append_diagnostics(diag_by_severity[ErrorSeverity.ERROR.name], line_numbers)
+        failed_producing_output = failed_producing_output or any(
+            x.kind == ErrorKind.PARSING for x in diag_by_severity[ErrorSeverity.ERROR.name]
+        )
     else:
         header += f"/*\n    Successfully transpiled from {file_path}\n"
 
-    if ErrorSeverity.WARNING in diag_by_severity:
+    if ErrorSeverity.WARNING.name in diag_by_severity:
         header += "\n    The following warnings were found while transpiling:\n"
-        for diag in diag_by_severity[ErrorSeverity.WARNING]:
-            if diag.range:
-                line_numbers[diag.range.start.line] = 0
-            header += _append_diagnostic(diag)
+        header += _append_diagnostics(diag_by_severity[ErrorSeverity.WARNING.name], line_numbers)
 
     if failed_producing_output:
         header += "\n\n    Parsing errors prevented the converter from translating the input query.\n"
@@ -206,13 +201,29 @@ def _make_header(file_path: Path, errors: list[TranspileError]) -> str:
     return header.format(line_numbers=line_numbers)
 
 
-def _append_diagnostic(diag: TranspileError) -> str:
-    message = diag.message.replace("{", "{{").replace("}", "}}")
-    if diag.range:
-        line = diag.range.start.line
-        column = diag.range.start.character + 1
-        return f"      - [{{line_numbers[{line}]}}:{column}] {message}\n"
-    return f"      - {message}\n"
+def _append_diagnostics(diagnostics: list[TranspileError], line_numbers: dict) -> str:
+    header = ""
+    grouped_by_message = {msg: list(diags) for msg, diags in itertools.groupby(diagnostics, lambda x: x.message)}
+    for msg, occurrences in grouped_by_message.items():
+        for o in occurrences:
+            if o.range:
+                line_numbers.update({o.range.start.line: 0})
+        header += _append_diagnostic(msg, occurrences)
+    return header
+
+
+def _append_diagnostic(msg: str, diags: list[TranspileError]) -> str:
+    positions = [
+        f"[{{line_numbers[{diag.range.start.line}]}}:{diag.range.start.character + 1}]" for diag in diags if diag.range
+    ]
+    message = msg.replace("{", "{{").replace("}", "}}").replace("/n", "\n        ")
+    result = f"      - {message}\n" if len(positions) != 1 else f"      - {positions[0]} {message}\n"
+    if len(positions) > 1:
+        positions_str = ", ".join(positions)
+        result += f"          Occurred {len(diags)} times at the following positions: {positions_str}\n"
+    elif len(diags) > 1:
+        result += f"          Occurred {len(diags)} times\n"
+    return result
 
 
 async def _process_many_files(

--- a/tests/unit/test_cli_transpile.py
+++ b/tests/unit/test_cli_transpile.py
@@ -364,4 +364,3 @@ def test_transpile_prints_errors(caplog, tmp_path, mock_workspace_client):
         )
 
     assert any(str(input_source) in record.message for record in caplog.records)
-    assert any("LCA conversion not supported" in record.message for record in caplog.records)

--- a/tests/unit/test_cli_transpile.py
+++ b/tests/unit/test_cli_transpile.py
@@ -363,5 +363,5 @@ def test_transpile_prints_errors(caplog, tmp_path, mock_workspace_client):
             error_file_path=error_file_path,
         )
 
-    assert any("TranspileError" in record.message for record in caplog.records)
+    assert any(str(input_source) in record.message for record in caplog.records)
     assert any("UNSUPPORTED_LCA" in record.message for record in caplog.records)

--- a/tests/unit/test_cli_transpile.py
+++ b/tests/unit/test_cli_transpile.py
@@ -364,4 +364,4 @@ def test_transpile_prints_errors(caplog, tmp_path, mock_workspace_client):
         )
 
     assert any(str(input_source) in record.message for record in caplog.records)
-    assert any("UNSUPPORTED_LCA" in record.message for record in caplog.records)
+    assert any("LCA conversion not supported" in record.message for record in caplog.records)


### PR DESCRIPTION
## Changes
### What does this PR do?

- Report only the count of errors/warnings to the console (each error/warning is still reported individually to `errors.log`)
- When the same error/warning message occurs multiple times, report it only once in the header message (with the number times it occurred and the individual positions).

### Functionality

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs lakebridge ...`
- [ ] ... +add your own

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [x] added unit tests
- [ ] added integration tests
