### PR TITLE
Create an issue template for creating docs issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,7 +3,3 @@ contact_links:
   - name: General Databricks questions
     url: https://help.databricks.com/
     about: Issues related to Databricks and not related to Lakebridge
-
-  - name: Lakebridge Documentation
-    url: https://databrickslabs.github.io/lakebridge/
-    about: Documentation about Lakebridge

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -3,7 +3,7 @@
 name: Documentation update
 description: Something new needs to be updated in the Lakebridge documentation
 title: "[DOCS]: "
-labels: ["needs-triage"]
+labels: ["needs-triage","documentation"]
 type: "task"
 
 body:

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,28 @@
+# See https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms
+# and https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema
+name: Documentation update
+description: Something new needs to be updated in the Lakebridge documentation
+title: "[DOCS]: "
+labels: ["needs-triage"]
+type: "task"
+
+body:
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please search to see if an issue already exists for the feature request you're willing to submit
+      options:
+        - label: I have searched the existing issues
+          required: true
+  - type: textarea
+    attributes:
+      label: Problem statement
+      description: A clear and concise description of what the problem is. Ex. The documentation is unclear how to do [...]
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Additional Context
+      description: Add any other context, references or screenshots about the feature request here.
+    validations:
+      required: false


### PR DESCRIPTION
<!-- REMOVE IRRELEVANT COMMENTS BEFORE CREATING A PULL REQUEST -->
## Changes
<!-- Summary of your changes that are easy to understand. Add screenshots when necessary, they're helpful to illustrate the before and after state -->
The previous link just went to the product docs, now creating an actual template for creating docs issues
### What does this PR do?
Removes the link to docs from the issues list, and instead opens a template.