### PR TITLE
Refactor parsing of `java -version` during `install-transpile`

### DIFF
--- a/src/databricks/labs/lakebridge/install.py
+++ b/src/databricks/labs/lakebridge/install.py
@@ -593,7 +593,9 @@ class WorkspaceInstaller:
             return None
         # It might not be ascii, but the bits we care about are so this will never fail.
         java_version_output = completed.stderr.decode("ascii", errors="ignore")
-        return cls._parse_java_version(java_version_output)
+        java_version = cls._parse_java_version(java_version_output)
+        logger.debug(f"Detected java version: {java_version}")
+        return java_version
 
     # Pattern to match a Java version string, compiled at import time to ensure it's valid.
     # Ref: https://docs.oracle.com/en/java/javase/11/install/version-string-format.html

--- a/src/databricks/labs/lakebridge/install.py
+++ b/src/databricks/labs/lakebridge/install.py
@@ -605,6 +605,8 @@ class WorkspaceInstaller:
         parts = version.split('.')
         return int(parts[0] + parts[1])
 
+    # Pattern to match a Java version string, compiled at import time to ensure it's valid.
+    # Ref: https://docs.oracle.com/en/java/javase/11/install/version-string-format.html
     _java_version_pattern = re.compile(
         r' version "(?P<feature>\d+)(?:\.(?P<interim>\d+)(?:\.(?P<update>\d+)(?:\.(?P<patch>\d+))?)?)?"'
     )
@@ -616,8 +618,6 @@ class WorkspaceInstaller:
         #   openjdk version "24.0.1" 2025-04-15
         #   OpenJDK Runtime Environment Temurin-24.0.1+9 (build 24.0.1+9)
         #   OpenJDK 64-Bit Server VM Temurin-24.0.1+9 (build 24.0.1+9, mixed mode)
-        # The version itself has been standardized since Java 10.
-        # Ref: https://docs.oracle.com/en/java/javase/11/install/version-string-format.html
         match = cls._java_version_pattern.search(version)
         if not match:
             logger.debug(f"Could not parse java version: {version!r}")

--- a/src/databricks/labs/lakebridge/install.py
+++ b/src/databricks/labs/lakebridge/install.py
@@ -585,7 +585,11 @@ class WorkspaceInstaller:
     def get_java_version(cls) -> int | None:
         try:
             completed = run(["java", "-version"], shell=False, capture_output=True, check=True)
-        except CalledProcessError:
+        except CalledProcessError as e:
+            logger.debug(
+                f"Failed to run {e.args!r} (exit-code={e.returncode}, stdout={e.stdout!r}, stderr={e.stderr!r})",
+                exc_info=e,
+            )
             return None
         result = completed.stderr.decode("utf-8")
         start = result.find(" version ")

--- a/src/databricks/labs/lakebridge/install.py
+++ b/src/databricks/labs/lakebridge/install.py
@@ -583,9 +583,8 @@ class WorkspaceInstaller:
 
     @classmethod
     def get_java_version(cls) -> int | None:
-        completed = run(["java", "-version"], shell=False, capture_output=True, check=False)
         try:
-            completed.check_returncode()
+            completed = run(["java", "-version"], shell=False, capture_output=True, check=True)
         except CalledProcessError:
             return None
         result = completed.stderr.decode("utf-8")

--- a/tests/integration/install/test_installer.py
+++ b/tests/integration/install/test_installer.py
@@ -114,6 +114,6 @@ def check_valid_version(version: str):
             assert False, f"{version} does not look like a valid semver"
 
 
-def test_java_version():
+def test_java_version() -> None:
     version = WorkspaceInstaller.get_java_version()
     assert version is None or version >= 110

--- a/tests/integration/install/test_installer.py
+++ b/tests/integration/install/test_installer.py
@@ -116,4 +116,4 @@ def check_valid_version(version: str):
 
 def test_java_version() -> None:
     version = WorkspaceInstaller.get_java_version()
-    assert version is None or version >= 110
+    assert version is None or version >= (11, 0, 0, 0)

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -1323,3 +1323,45 @@ def test_store_product_state(tmp_path) -> None:
         "date": stored_date,
     }
     assert stored_state == expected_state
+
+
+class FriendOfWorkspaceInstaller(WorkspaceInstaller):
+    """A friend class to access protected methods for testing purposes."""
+
+    @classmethod
+    def parse_java_version(cls, output: str) -> tuple[int, int, int, int] | None:
+        return cls._parse_java_version(output)
+
+
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    (
+        # Real examples.
+        pytest.param("1.8.0_452", None, id="1.8.0_452"),
+        pytest.param("11.0.27", (11, 0, 27, 0), id="11.0.27"),
+        pytest.param("17.0.15", (17, 0, 15, 0), id="17.0.15"),
+        pytest.param("21.0.7", (21, 0, 7, 0), id="21.0.7"),
+        pytest.param("24.0.1", (24, 0, 1, 0), id="24.0.1"),
+        # All digits.
+        pytest.param("1.2.3.4", (1, 2, 3, 4), id="1.2.3.4"),
+        # Trailing zeros can be omitted.
+        pytest.param("1.2.3", (1, 2, 3, 0), id="1.2.3"),
+        pytest.param("1.2", (1, 2, 0, 0), id="1.2"),
+        pytest.param("1", (1, 0, 0, 0), id="1"),
+        # Another edge case.
+        pytest.param("", None, id="empty string"),
+    ),
+)
+def test_java_version_parse(version: str, expected: tuple[int, int, int, int] | None) -> None:
+    """Verify that the Java version parsing works correctly."""
+    # Format reference: https://docs.oracle.com/en/java/javase/11/install/version-string-format.html
+    version_output = f'openjdk version "{version}" 2025-06-19'
+    parsed = FriendOfWorkspaceInstaller.parse_java_version(version_output)
+    assert parsed == expected
+
+
+def test_java_version_parse_missing() -> None:
+    """Verify that we return None when the version is missing."""
+    version_output = "Nothing in here that looks like a version."
+    parsed = FriendOfWorkspaceInstaller.parse_java_version(version_output)
+    assert parsed is None


### PR DESCRIPTION
## Changes

### What does this PR do?

This PR replaces the custom parsing we had in place for the installed version of Java. Changes include:

 - Handling the version as a 4-tuple.
 - Using a regex instead of a custom parser.
 - The [specification][1] allows a version to be just a single digit (eg. `28`); this would cause the previous code to crash.

Further to this, to aid with support:

 - We now log the version of java that was detected.
 - If an error occurs while running `java -version` we now log information about what happened.

### Relevant implementation details

The specification for java version strings is [here][1].

### Caveats/things to watch out for when reviewing:

Optional groups within a pattern yield `None` if they weren't part of the match.

### Linked issues

This follows on from [a comment](https://github.com/databrickslabs/lakebridge/pull/1537/files#r2075491051) on #1537, where this code was originally implemented.

### Functionality

- modified existing command: `databricks labs lakebridge install-transpile`

### Tests

- manually tested:
  ```
  15:20:20    DEBUG [d.l.lakebridge.install] Detected java version: (24, 0, 1, 0)
  ```
- added unit tests
- existing integration tests

[1]: https://docs.oracle.com/en/java/javase/11/install/version-string-format.html