### PR TITLE
Detect (and remove) Unicode BOMs when reading SQL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ dependencies = [
   "standard-distutils~=3.11.9; python_version>='3.11'",
   "databricks-bb-analyzer~=0.1.6",
   "sqlglot==26.1.3",
-  "databricks-labs-blueprint[yaml]>=0.11.0,<0.12.0",
+  #"databricks-labs-blueprint[yaml]>=0.11.0,<0.12.0",
+  "databricks-labs-blueprint @ git+https://github.com/databrickslabs/blueprint@port-read-text-with-bom",
   "databricks-labs-lsql==0.16.0",
   "cryptography>=44.0.2,<45.1.0",
   "pyodbc~=5.2.0",
@@ -52,6 +53,9 @@ build-backend = "hatchling.build"
 [tool.hatch.build]
 sources = ["src"]
 include = ["src"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 path = "src/databricks/labs/lakebridge/__about__.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   "databricks-bb-analyzer~=0.1.7",
   "sqlglot==26.1.3",
   #"databricks-labs-blueprint[yaml]>=0.11.0,<0.12.0",
-  "databricks-labs-blueprint @ git+https://github.com/databrickslabs/blueprint@port-read-text-with-bom",
+  "databricks-labs-blueprint @ git+https://github.com/databrickslabs/blueprint@main",
   "databricks-labs-lsql==0.16.0",
   "cryptography>=44.0.2,<45.1.0",
   "pyodbc~=5.2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,7 @@ dependencies = [
   "standard-distutils~=3.11.9; python_version>='3.11'",
   "databricks-bb-analyzer~=0.1.7",
   "sqlglot==26.1.3",
-  #"databricks-labs-blueprint[yaml]>=0.11.0,<0.12.0",
-  "databricks-labs-blueprint @ git+https://github.com/databrickslabs/blueprint@main",
+  "databricks-labs-blueprint[yaml]>=0.11.1,<0.12.0",
   "databricks-labs-lsql==0.16.0",
   "cryptography>=44.0.2,<45.1.0",
   "pyodbc~=5.2.0",
@@ -53,9 +52,6 @@ build-backend = "hatchling.build"
 [tool.hatch.build]
 sources = ["src"]
 include = ["src"]
-
-[tool.hatch.metadata]
-allow-direct-references = true
 
 [tool.hatch.version]
 path = "src/databricks/labs/lakebridge/__about__.py"

--- a/src/databricks/labs/lakebridge/helpers/file_utils.py
+++ b/src/databricks/labs/lakebridge/helpers/file_utils.py
@@ -51,14 +51,3 @@ def get_sql_file(input_path: str | Path) -> Generator[Path, None, None]:
         for filename in files:
             if is_sql_file(filename):
                 yield filename
-
-
-def read_file(filename: str | Path) -> str:
-    """
-    Reads the contents of the given file and returns it as a string.
-    :param filename: Input File Path
-    :return: File Contents as String
-    """
-    # pylint: disable=unspecified-encoding
-    with Path(filename).open() as file:
-        return file.read()

--- a/src/databricks/labs/lakebridge/helpers/string_utils.py
+++ b/src/databricks/labs/lakebridge/helpers/string_utils.py
@@ -1,37 +1,3 @@
-import codecs
-
-
-# Optionally check to see if a string begins with a Byte Order Mark
-# such a character will cause the transpiler to fail
-def remove_bom(input_string: str) -> str:
-    """
-    Removes the Byte Order Mark (BOM) from the given string if it exists.
-    :param input_string: String to remove BOM from
-    :return: String without BOM
-    """
-    output_string = input_string
-
-    # Check and remove UTF-16 (LE and BE) BOM
-    if input_string.startswith(codecs.BOM_UTF16_BE.decode("utf-16-be")):
-        output_string = input_string[len(codecs.BOM_UTF16_BE.decode("utf-16-be")) :]
-    elif input_string.startswith(codecs.BOM_UTF16_LE.decode("utf-16-le")):
-        output_string = input_string[len(codecs.BOM_UTF16_LE.decode("utf-16-le")) :]
-    elif input_string.startswith(codecs.BOM_UTF16.decode("utf-16")):
-        output_string = input_string[len(codecs.BOM_UTF16.decode("utf-16")) :]
-    # Check and remove UTF-32 (LE and BE) BOM
-    elif input_string.startswith(codecs.BOM_UTF32_BE.decode("utf-32-be")):
-        output_string = input_string[len(codecs.BOM_UTF32_BE.decode("utf-32-be")) :]
-    elif input_string.startswith(codecs.BOM_UTF32_LE.decode("utf-32-le")):
-        output_string = input_string[len(codecs.BOM_UTF32_LE.decode("utf-32-le")) :]
-    elif input_string.startswith(codecs.BOM_UTF32.decode("utf-32")):
-        output_string = input_string[len(codecs.BOM_UTF32.decode("utf-32")) :]
-    # Check and remove UTF-8 BOM
-    elif input_string.startswith(codecs.BOM_UTF8.decode("utf-8")):
-        output_string = input_string[len(codecs.BOM_UTF8.decode("utf-8")) :]
-
-    return output_string
-
-
 def refactor_hexadecimal_chars(input_string: str) -> str:
     """
     Updates the HexaDecimal characters ( \x1b[\\d+m ) in the given string as below.

--- a/src/databricks/labs/lakebridge/intermediate/root_tables.py
+++ b/src/databricks/labs/lakebridge/intermediate/root_tables.py
@@ -1,11 +1,9 @@
 import logging
 from pathlib import Path
 
-from databricks.labs.lakebridge.helpers.file_utils import (
-    get_sql_file,
-    is_sql_file,
-    read_file,
-)
+from databricks.labs.blueprint.paths import read_text
+
+from databricks.labs.lakebridge.helpers.file_utils import get_sql_file, is_sql_file
 from databricks.labs.lakebridge.intermediate.dag import DAG
 
 from databricks.labs.lakebridge.transpiler.sqlglot.sqlglot_engine import SqlglotEngine
@@ -26,14 +24,14 @@ class RootTableAnalyzer:
         # when input is sql file then parse the file
         if is_sql_file(self.input_path):
             logger.debug(f"Generating Lineage file: {self.input_path}")
-            sql_content = read_file(self.input_path)
+            sql_content = read_text(self.input_path)
             self._populate_dag(sql_content, self.input_path, dag)
             return dag  # return after processing the file
 
         # when the input is a directory
         for path in get_sql_file(self.input_path):
             logger.debug(f"Generating Lineage file: {path}")
-            sql_content = read_file(path)
+            sql_content = read_text(path)
             self._populate_dag(sql_content, path, dag)
 
         return dag

--- a/src/databricks/labs/lakebridge/transpiler/execute.py
+++ b/src/databricks/labs/lakebridge/transpiler/execute.py
@@ -9,6 +9,7 @@ from typing import cast
 import itertools
 
 from databricks.labs.blueprint.installation import JsonObject
+from databricks.labs.blueprint.paths import read_text
 from databricks.labs.lakebridge.__about__ import __version__
 from databricks.labs.lakebridge.config import (
     TranspileConfig,
@@ -28,7 +29,6 @@ from databricks.labs.lakebridge.transpiler.transpile_status import (
     ErrorKind,
     ErrorSeverity,
 )
-from databricks.labs.lakebridge.helpers.string_utils import remove_bom
 from databricks.labs.lakebridge.helpers.validation import Validator
 from databricks.labs.lakebridge.transpiler.sqlglot.sqlglot_engine import SqlglotEngine
 from databricks.sdk import WorkspaceClient
@@ -62,15 +62,14 @@ async def _process_one_file(context: TranspilingContext) -> tuple[int, list[Tran
         )
         return 0, [error]
 
-    with context.input_path.open("r") as f:
-        source_code = remove_bom(f.read())
-        context = dataclasses.replace(context, source_code=source_code)
+    source_code = read_text(context.input_path)
+    context = dataclasses.replace(context, source_code=source_code)
 
     transpile_result = await _transpile(
         context.transpiler,
         str(context.config.source_dialect),
         context.config.target_dialect,
-        str(context.source_code),
+        source_code,
         context.input_path,
     )
 

--- a/src/databricks/labs/lakebridge/transpiler/lsp/lsp_engine.py
+++ b/src/databricks/labs/lakebridge/transpiler/lsp/lsp_engine.py
@@ -523,9 +523,7 @@ class LSPEngine(TranspileEngine):
         self.close_document(file_path)
         return ChangeManager.apply(source_code, response.changes, response.diagnostics, file_path)
 
-    def open_document(self, file_path: Path, encoding="utf-8", source_code: str | None = None) -> None:
-        if source_code is None:
-            source_code = file_path.read_text(encoding)
+    def open_document(self, file_path: Path, source_code: str) -> None:
         text_document = TextDocumentItem(
             uri=file_path.as_uri(), language_id=LanguageKind.Sql, version=1, text=source_code
         )

--- a/tests/unit/helpers/test_string_utils.py
+++ b/tests/unit/helpers/test_string_utils.py
@@ -1,44 +1,4 @@
-import codecs
-
-from databricks.labs.lakebridge.helpers.string_utils import remove_bom, refactor_hexadecimal_chars, format_error_message
-
-
-def test_remove_bom():
-    test_string = "test_string"
-
-    # Test no BOM
-    assert remove_bom(test_string) == test_string
-
-    # Test UTF-16 BOM
-    # "******** UTF-16 ********"
-    input_string = codecs.BOM_UTF16.decode("utf-16") + test_string
-    assert remove_bom(input_string) == test_string
-
-    # "******** UTF-16-BE ********"
-    input_string = codecs.BOM_UTF16_BE.decode("utf-16-be") + test_string
-    assert remove_bom(input_string) == test_string
-
-    # "******** UTF-16-LE ********"
-    input_string = codecs.BOM_UTF16_LE.decode("utf-16-le") + test_string
-    assert remove_bom(input_string) == test_string
-
-    # Test UTF-32 BOM
-    # "******** UTF-32 ********"
-    input_string = codecs.BOM_UTF32.decode("utf-32") + test_string
-    assert remove_bom(input_string) == test_string
-
-    # "******** UTF-32-BE ********"
-    input_string = codecs.BOM_UTF32_BE.decode("utf-32-be") + test_string
-    assert remove_bom(input_string) == test_string
-
-    # "******** UTF-32-LE ********"
-    input_string = codecs.BOM_UTF32_LE.decode("utf-32-le") + test_string
-    assert remove_bom(input_string) == test_string
-
-    # Test UTF8 BOM
-    # "******** UTF-8 ********"
-    input_string = codecs.BOM_UTF8.decode("utf-8") + test_string
-    assert remove_bom(input_string) == test_string
+from databricks.labs.lakebridge.helpers.string_utils import refactor_hexadecimal_chars, format_error_message
 
 
 def test_refactor_hexadecimal_chars():

--- a/tests/unit/transpiler/test_execute.py
+++ b/tests/unit/transpiler/test_execute.py
@@ -31,6 +31,7 @@ from databricks.labs.lakebridge.transpiler.transpile_status import (
     ErrorKind,
 )
 
+from databricks.labs.blueprint.installation import JsonObject
 from databricks.sdk.core import Config
 
 from databricks.labs.lakebridge.transpiler.sqlglot.sqlglot_engine import SqlglotEngine
@@ -42,7 +43,9 @@ from tests.unit.conftest import path_to_resource
 # pylint: disable=unspecified-encoding
 
 
-def transpile(workspace_client: WorkspaceClient, engine: TranspileEngine, config: TranspileConfig):
+def transpile(
+    workspace_client: WorkspaceClient, engine: TranspileEngine, config: TranspileConfig
+) -> tuple[JsonObject, list[TranspileError]]:
     return asyncio.run(do_transpile(workspace_client, engine, config))
 
 

--- a/tests/unit/transpiler/test_execute.py
+++ b/tests/unit/transpiler/test_execute.py
@@ -13,7 +13,7 @@ from databricks.labs.lsql.backends import MockBackend
 from databricks.labs.lsql.core import Row
 from databricks.sdk import WorkspaceClient
 
-from databricks.labs.lakebridge.config import TranspileConfig, ValidationResult
+from databricks.labs.lakebridge.config import TranspileConfig, ValidationResult, TranspileResult
 from databricks.labs.lakebridge.helpers.file_utils import dir_walk, is_sql_file
 from databricks.labs.lakebridge.helpers.validation import Validator
 from databricks.labs.lakebridge.transpiler.execute import (
@@ -178,6 +178,61 @@ def test_with_file(input_source, error_file, mock_workspace_client):
     # check errors
     expected_errors = [{"path": f"{input_source!s}/queries/query1.sql", "message": "Mock validation error"}]
     check_error_lines(status["error_log_file"], expected_errors)
+
+
+class IdentityTranspileEngine(TranspileEngine):
+    """A simple "identity" transpiler that does not change the source it is given."""
+
+    @property
+    def supported_dialects(self) -> list[str]:
+        return ["identity"]
+
+    async def initialize(self, config: TranspileConfig) -> None:
+        assert config.source_dialect in self.supported_dialects
+
+    async def shutdown(self) -> None:
+        # Nothing needed here.
+        return
+
+    async def transpile(
+        self, source_dialect: str, target_dialect: str, source_code: str, file_path: Path
+    ) -> TranspileResult:
+        assert source_dialect in self.supported_dialects
+        return TranspileResult(
+            transpiled_code=source_code,
+            success_count=1,
+            error_list=[],
+        )
+
+    def is_supported_file(self, file: Path) -> bool:
+        return True
+
+
+@pytest.mark.parametrize("encoding", ["utf-32-le", "utf-32-be", "utf-16-le", "utf-16-be", "utf-8-sig", "utf-8"])
+def test_transpile_unicode_files(
+    encoding: str, tmp_path: Path, output_folder: Path, mock_workspace_client: WorkspaceClient
+) -> None:
+    # Set up the test: an input file with a specific encoding.
+    sample_query = "SELECT 'All your base belong to us.\U0001f47d'"
+    input_file = tmp_path / "unicode_query.sql"
+    with open(input_file, "w", encoding=encoding) as f:
+        # Python doesn't write the BOM with the endian-specific encodings so we add it manually.
+        if encoding.endswith("-le") or encoding.endswith("-be"):
+            f.write("\ufeff")
+        f.write(sample_query)
+
+    transpile_config = TranspileConfig(
+        transpiler_config_path=None,
+        source_dialect="identity",
+        input_source=str(input_file),
+        output_folder=str(output_folder),
+        skip_validation=True,
+    )
+    status, _ = transpile(mock_workspace_client, IdentityTranspileEngine(), transpile_config)
+
+    assert status.get("total_files_processed") == 1
+    transpiled_query = (output_folder / "unicode_query.sql").read_text(encoding="utf-8")
+    assert sample_query == transpiled_query
 
 
 def test_with_file_with_output_folder_skip_validation(input_source, output_folder, mock_workspace_client):

--- a/tests/unit/transpiler/test_lsp_engine.py
+++ b/tests/unit/transpiler/test_lsp_engine.py
@@ -9,9 +9,12 @@ import pytest
 
 from lsprotocol.types import TextEdit, Range, Position
 
+from databricks.labs.blueprint.paths import read_text
 from databricks.labs.blueprint.wheels import ProductInfo
+
+from databricks.labs.lakebridge.config import TranspileConfig
 from databricks.labs.lakebridge.errors.exceptions import IllegalStateException
-from databricks.labs.lakebridge.transpiler.lsp.lsp_engine import ChangeManager
+from databricks.labs.lakebridge.transpiler.lsp.lsp_engine import ChangeManager, LSPEngine
 from databricks.labs.lakebridge.transpiler.transpile_status import TranspileError, ErrorSeverity, ErrorKind
 
 from tests.unit.conftest import path_to_resource
@@ -108,18 +111,18 @@ async def test_server_fetches_workspace_file(lsp_engine, transpile_config):
     assert f"fetch-document-uri={sample_path.as_uri()}" in log
 
 
-async def test_server_loads_document(lsp_engine, transpile_config):
+async def test_server_loads_document(lsp_engine: LSPEngine, transpile_config: TranspileConfig) -> None:
     sample_path = Path(path_to_resource("lsp_transpiler", "source_stuff.sql"))
     await lsp_engine.initialize(transpile_config)
-    lsp_engine.open_document(sample_path)
+    lsp_engine.open_document(sample_path, read_text(sample_path))
     log = await read_log("open-document-uri")
     assert f"open-document-uri={sample_path.as_uri()}" in log
 
 
-async def test_server_closes_document(lsp_engine, transpile_config):
+async def test_server_closes_document(lsp_engine: LSPEngine, transpile_config: TranspileConfig) -> None:
     sample_path = Path(path_to_resource("lsp_transpiler", "source_stuff.sql"))
     await lsp_engine.initialize(transpile_config)
-    lsp_engine.open_document(sample_path)
+    lsp_engine.open_document(sample_path, read_text(sample_path))
     lsp_engine.close_document(sample_path)
     log = await read_log("close-document-uri")
     assert f"close-document-uri={sample_path.as_uri()}" in log


### PR DESCRIPTION
## Changes

### What does this PR do?

This PR updates the code-paths that read SQL files to detect (and remove if present) any Unicode-BOM that specifies the file encoding.

### Relevant implementation details

This depends on upstream functionality: databrickslabs/blueprint#243.

Further to using the upstream functionality, this PR removes some code:

 - `read_file()` replaced by `read_text()` from blueprint.
 - `remove_bom()` this was incorrect, and has also been replaced by `read_text()`.
 - A dead code-path was removed.

### Caveats/things to watch out for when reviewing:

This branch depends on a development branch of blueprint; this needs to be replaced with the released version before merging.

### Linked issues

Requires: databrickslabs/blueprint#243
Partially supersedes: #1689
Resolves: #1516

### Functionality

- modified existing command: `databricks labs lakebridge transpile`

### Tests

- added unit tests
