### PR TITLE
Disable header comments

### DIFF
--- a/src/databricks/labs/lakebridge/transpiler/execute.py
+++ b/src/databricks/labs/lakebridge/transpiler/execute.py
@@ -158,7 +158,7 @@ def _process_single_result(context: TranspilingContext, error_list: list[Transpi
 
     output_path = cast(Path, context.output_path)
     with output_path.open("w") as w:
-        w.write(make_header(context.input_path, error_list))
+        #w.write(make_header(context.input_path, error_list))
         w.write(output_code)
 
     logger.info(f"Processed file: {context.input_path} (errors: {len(error_list)})")


### PR DESCRIPTION
Disable the generation of header comment summarizing the encountered errors/warnings as they may make `.py` or `.json` files incorrect.