### PR TITLE
SQL Server exporting legacy metadata documentation

### DIFF
--- a/docs/lakebridge/docs/assessment/analyzer/export_metadata.mdx
+++ b/docs/lakebridge/docs/assessment/analyzer/export_metadata.mdx
@@ -50,6 +50,12 @@ You’ll need to export the DTSX packages. For details on how to obtain it see: 
 
 In many cases the DTSX packages can also be just copied to the analyzer folder.
 
+## SQL Server
+
+You’ll need to export the SQL Script. For details on how to obtain it see: https://learn.microsoft.com/en-us/ssms/scripting/generate-and-publish-scripts-wizard
+
+Note: The SQL Script should be split to have more accurate results
+
 ## Talend
 
 To export all jobs in bulk, right click on Job Designs and select "Export Items".  In the popup, select "Include All Dependencies"

--- a/docs/lakebridge/docs/assessment/analyzer/export_metadata.mdx
+++ b/docs/lakebridge/docs/assessment/analyzer/export_metadata.mdx
@@ -54,7 +54,7 @@ In many cases the DTSX packages can also be just copied to the analyzer folder.
 
 You’ll need to export the SQL Script. For details on how to obtain it see: https://learn.microsoft.com/en-us/ssms/scripting/generate-and-publish-scripts-wizard
 
-Note: The SQL Script should be split to have more accurate results
+Note: The SQL Script file should be split to have more accurate results
 
 ## Talend
 


### PR DESCRIPTION
## Changes
Added documentation on how to generate the metadata for SQL Server in the Analyzer Guide
### What does this PR do?
Expand the documentation

### Linked issues
No Issues linked

### Functionality

- [X ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs lakebridge ...`
- [ ] ... +add your own

### Tests
No test needed

