### PR TITLE
Improve diagnostics if the Java check fails prior to installing morpheus

### DIFF
--- a/src/databricks/labs/lakebridge/install.py
+++ b/src/databricks/labs/lakebridge/install.py
@@ -581,7 +581,8 @@ class WorkspaceInstaller:
                 logger.warning(f"Java found ({java_executable}), but could not parse the version:\n{raw_version}")
                 return False
             case (java_executable, tuple(old_version)) if old_version < (11, 0, 0, 0):
-                logger.warning(f"Java found ({java_executable}), but version {'.'.join(old_version)} is too old.")
+                version_str = ".".join(str(v) for v in old_version)
+                logger.warning(f"Java found ({java_executable}), but version {version_str} is too old.")
                 return False
             case _:
                 return True

--- a/src/databricks/labs/lakebridge/install.py
+++ b/src/databricks/labs/lakebridge/install.py
@@ -557,16 +557,34 @@ class WorkspaceInstaller:
 
     @classmethod
     def install_morpheus(cls, artifact: Path | None = None):
-        java_version = cls.get_java_version()
-        if java_version is None or java_version < (11, 0, 0, 0):
-            logger.warning(
-                "This software requires Java 11 or above. Please install Java and re-run 'install-transpile'."
+        if not cls.is_java_version_okay():
+            logger.error(
+                "The morpheus transpiler requires Java 11 or above. Please install Java and re-run 'install-transpile'."
             )
             return
         product_name = "databricks-morph-plugin"
         group_id = "com.databricks.labs"
         artifact_id = product_name
         TranspilerInstaller.install_from_maven(product_name, group_id, artifact_id, artifact)
+
+    @classmethod
+    def is_java_version_okay(cls) -> bool:
+        detected_java = cls.find_java()
+        match detected_java:
+            case None:
+                logger.warning("No Java executable found in the system PATH.")
+                return False
+            case (java_executable, None):
+                logger.warning(f"Java found, but could not determine the version: {java_executable}.")
+                return False
+            case (java_executable, bytes(raw_version)):
+                logger.warning(f"Java found ({java_executable}), but could not parse the version:\n{raw_version}")
+                return False
+            case (java_executable, tuple(old_version)) if old_version < (11, 0, 0, 0):
+                logger.warning(f"Java found ({java_executable}), but version {'.'.join(old_version)} is too old.")
+                return False
+            case _:
+                return True
 
     @classmethod
     def install_artifact(cls, artifact: str):
@@ -582,25 +600,42 @@ class WorkspaceInstaller:
             logger.fatal(f"Cannot install unsupported artifact: {artifact}")
 
     @classmethod
-    def get_java_version(cls) -> tuple[int, int, int, int] | None:
+    def find_java(cls) -> tuple[Path, tuple[int, int, int, int] | bytes | None] | None:
+        """Locate Java and return its version, as reported by `java -version`.
+
+        The java executable is currently located by searching the system PATH. Its version is parsed from the output of
+        the `java -version` command, which has been standardized since Java 10.
+
+        Returns:
+            a tuple of its path and the version as a tuple of integers (feature, interim, update, patch), if the java
+            executable could be located. If the version cannot be parsed, instead the raw version information is
+            returned, or `None` as a last resort. When no java executable is found, `None` is returned instead of a
+            tuple.
+        """
         # Platform-independent way to reliably locate the java executable.
         # Reference: https://docs.python.org/3.10/library/subprocess.html#popen-constructor
         java_executable = shutil.which("java")
         if java_executable is None:
             return None
+        java_executable_path = Path(java_executable)
+        logger.debug(f"Using java executable: {java_executable_path!r}")
         try:
-            completed = run([java_executable, "-version"], shell=False, capture_output=True, check=True)
+            completed = run([str(java_executable_path), "-version"], shell=False, capture_output=True, check=True)
         except CalledProcessError as e:
             logger.debug(
                 f"Failed to run {e.args!r} (exit-code={e.returncode}, stdout={e.stdout!r}, stderr={e.stderr!r})",
                 exc_info=e,
             )
-            return None
+            return java_executable_path, None
         # It might not be ascii, but the bits we care about are so this will never fail.
-        java_version_output = completed.stderr.decode("ascii", errors="ignore")
+        raw_output = completed.stderr
+        java_version_output = raw_output.decode("ascii", errors="ignore")
         java_version = cls._parse_java_version(java_version_output)
+        if java_version is None:
+            logger.debug(f"Could not parse java version from output: {java_version_output!r}")
+            return java_executable_path, raw_output.strip()
         logger.debug(f"Detected java version: {java_version}")
-        return java_version
+        return java_executable_path, java_version
 
     # Pattern to match a Java version string, compiled at import time to ensure it's valid.
     # Ref: https://docs.oracle.com/en/java/javase/11/install/version-string-format.html

--- a/src/databricks/labs/lakebridge/install.py
+++ b/src/databricks/labs/lakebridge/install.py
@@ -632,7 +632,6 @@ class WorkspaceInstaller:
         java_version_output = raw_output.decode("ascii", errors="ignore")
         java_version = cls._parse_java_version(java_version_output)
         if java_version is None:
-            logger.debug(f"Could not parse java version from output: {java_version_output!r}")
             return java_executable_path, raw_output.strip()
         logger.debug(f"Detected java version: {java_version}")
         return java_executable_path, java_version

--- a/tests/integration/install/test_installer.py
+++ b/tests/integration/install/test_installer.py
@@ -115,5 +115,12 @@ def check_valid_version(version: str):
 
 
 def test_java_version() -> None:
-    version = WorkspaceInstaller.get_java_version()
-    assert version is None or version >= (11, 0, 0, 0)
+    result = WorkspaceInstaller.find_java()
+    match result:
+        case None:
+            # Fine, no Java available.
+            pass
+        case (java_home, tuple(version)):
+            assert java_home.exists() and version >= (11, 0, 0, 0)
+        case _:
+            pytest.fail(f"Unexpected result from WorkspaceInstaller.find_java(): {result!r}")

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -1350,7 +1350,7 @@ def no_java(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_java_version_with_java_missing(no_java: None) -> None:
     """Verify the Java version check handles Java missing entirely."""
-    expected_missing = WorkspaceInstaller.get_java_version()
+    expected_missing = WorkspaceInstaller.find_java()
     assert expected_missing is None
 
 


### PR DESCRIPTION
## Changes
### What does this PR do?

This PR updates the check for Java when installing Morpheus so that we differentiate between the different causes of failure, and provide more information to the user if it fails. All code-paths now have a `WARNING` that describes the problem, followed by (the same) `ERROR` indicating that we need Java 11 or later.

### Linked issues

Resolves #1768 

### Functionality

- modified existing command: `databricks labs lakebridge install-transpile`

### Tests

- manually tested
- updated unit tests
- updated integration tests

#### Sample output

When Java cannot be found at all:
```
17:07:53  WARNING [d.l.lakebridge.install] No Java executable found in the system PATH.
17:07:53    ERROR [d.l.lakebridge.install] The morpheus transpiler requires Java 11 or above. Please install Java and re-run 'install-transpile'.
```

When Java can be found, but running it fails:
```
17:14:04    DEBUG [d.l.lakebridge.install] Using java executable: PosixPath('/tmp/x/java')
17:14:04    DEBUG [d.l.lakebridge.install] Failed to run (1, ['/tmp/x/java', '-version']) (exit-code=1, stdout=b'', stderr=b'This is not the Java you are looking for.\n')
Traceback (most recent call last):
  File "/Users/**REDACTED**/dev/remorph-2/src/databricks/labs/lakebridge/install.py", line 624, in find_java
    completed = run([str(java_executable_path), "-version"], shell=False, capture_output=True, check=True)
  File "/Users/**REDACTED**/Library/Application Support/hatch/env/virtual/.pythons/3.10/python/lib/python3.10/subprocess.py", line 526, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['/tmp/x/java', '-version']' returned non-zero exit status 1.
17:14:04  WARNING [d.l.lakebridge.install] Java found, but could not determine the version: /tmp/x/java.
17:14:04    ERROR [d.l.lakebridge.install] The morpheus transpiler requires Java 11 or above. Please install Java and re-run 'install-transpile'.
```

When Java can be found but the version can't be parsed, for example with Java 1.8:
```
15:55:07    DEBUG [d.l.lakebridge.install] Using java executable: PosixPath('/usr/bin/java')
15:55:07    DEBUG [d.l.lakebridge.install] Could not parse java version: 'openjdk version "1.8.0_452"\nOpenJDK Runtime Environment (Temurin)(build 1.8.0_452-b09)\nOpenJDK 64-Bit Server VM (Temurin)(build 25.452-b09, mixed mode)\n'
15:55:07  WARNING [d.l.lakebridge.install] Java found (/usr/bin/java), but could not parse the version:
b'openjdk version "1.8.0_452"\nOpenJDK Runtime Environment (Temurin)(build 1.8.0_452-b09)\nOpenJDK 64-Bit Server VM (Temurin)(build 25.452-b09, mixed mode)'
15:55:07    ERROR [d.l.lakebridge.install] The morpheus transpiler requires Java 11 or above. Please install Java and re-run 'install-transpile'.
```

When Java can be found but (the parsed version) is too old:
```
17:02:13    DEBUG [d.l.lakebridge.install] Using java executable: PosixPath('/tmp/jdk-10.0.2.jdk/Contents/Home/bin/java')
17:02:13    DEBUG [d.l.lakebridge.install] Detected java version: (10, 0, 2, 0)
17:02:13  WARNING [d.l.lakebridge.install] Java found (/tmp/jdk-10.0.2.jdk/Contents/Home/bin/java), but version 10.0.2.0 is too old.
17:02:13    ERROR [d.l.lakebridge.install] The morpheus transpiler requires Java 11 or above. Please install Java and re-run 'install-transpile'.
```

Normal install with Java 11:
```
17:19:14    DEBUG [d.l.lakebridge.install] Using java executable: PosixPath('/usr/bin/java')
17:19:15    DEBUG [d.l.lakebridge.install] Detected java version: (11, 0, 27, 0)
17:19:15    DEBUG [d.l.lakebridge.install] Maven metadata for com.databricks.labs:databricks-morph-plugin: b'<?xml version="1.0" encoding="UTF-8"?>\n<metadata>\n  <groupId>com.databricks.labs</groupId>\n  <artifactId>databricks-morph-plugin</artifactId>\n  <versioning>\n    <latest>0.6.1</latest>\n    <release>0.6.1</release>\n    <versions>\n      <version>0.2.0</version>\n      <version>0.3.0</version>\n      <version>0.4.0</version>\n      <version>0.5.0</version>\n      <version>0.6.0</version>\n      <version>0.6.1</version>\n    </versions>\n    <lastUpdated>20250625163046</lastUpdated>\n  </versioning>\n</metadata>\n'
17:19:15     INFO [d.l.lakebridge.install] Installing Databricks databricks-morph-plugin transpiler v0.6.1
17:19:19    DEBUG [d.l.lakebridge.install] Downloaded maven artefact from https://repo.maven.apache.org/maven2/com/databricks/labs/databricks-morph-plugin/0.6.1/databricks-morph-plugin-0.6.1.jar to /var/folders/gt/bjf87q2s7db3zq4jbn8694r80000gp/T/tmpczfc7vrb
17:19:19    DEBUG [d.l.lakebridge.install] Moving /var/folders/gt/bjf87q2s7db3zq4jbn8694r80000gp/T/tmpczfc7vrb to /Users/**REDACTED**/.databricks/labs/remorph-transpilers/databricks-morph-plugin/lib/databricks-morph-plugin.jar
17:19:19     INFO [d.l.lakebridge.install] Successfully installed: com.databricks.labs:databricks-morph-plugin:0.6.1
17:19:19     INFO [d.l.lakebridge.install] Successfully installed databricks-morph-plugin v0.6.1
```