### PR TITLE
Enabled TSQL Recon

### DIFF
--- a/labs.yml
+++ b/labs.yml
@@ -25,7 +25,7 @@ commands:
         description: Dialect name
         default: null
       - name: input-source
-        description: Input SQL Folder or File
+        description: Input Script Folder or File
         default: null
       - name: output-folder
         description: Output Location For Storing Transpiled Code, defaults to input-source folder

--- a/src/databricks/labs/lakebridge/reconcile/connectors/source_adapter.py
+++ b/src/databricks/labs/lakebridge/reconcile/connectors/source_adapter.py
@@ -6,7 +6,7 @@ from databricks.labs.lakebridge.reconcile.connectors.data_source import DataSour
 from databricks.labs.lakebridge.reconcile.connectors.databricks import DatabricksDataSource
 from databricks.labs.lakebridge.reconcile.connectors.oracle import OracleDataSource
 from databricks.labs.lakebridge.reconcile.connectors.snowflake import SnowflakeDataSource
-from databricks.labs.lakebridge.reconcile.connectors.sql_server import SQLServerDataSource
+from databricks.labs.lakebridge.reconcile.connectors.tsql import TSQLServerDataSource
 from databricks.labs.lakebridge.transpiler.sqlglot.generator.databricks import Databricks
 from databricks.labs.lakebridge.transpiler.sqlglot.parsers.oracle import Oracle
 from databricks.labs.lakebridge.transpiler.sqlglot.parsers.snowflake import Snowflake
@@ -26,5 +26,5 @@ def create_adapter(
     if isinstance(engine, Databricks):
         return DatabricksDataSource(engine, spark, ws, secret_scope)
     if isinstance(engine, TSQL):
-        return SQLServerDataSource(engine, spark, ws, secret_scope)
+        return TSQLServerDataSource(engine, spark, ws, secret_scope)
     raise ValueError(f"Unsupported source type --> {engine}")

--- a/src/databricks/labs/lakebridge/reconcile/connectors/tsql.py
+++ b/src/databricks/labs/lakebridge/reconcile/connectors/tsql.py
@@ -47,7 +47,7 @@ _SCHEMA_QUERY = """SELECT
               """
 
 
-class SQLServerDataSource(DataSource, SecretsMixin, JDBCReaderMixin):
+class TSQLServerDataSource(DataSource, SecretsMixin, JDBCReaderMixin):
     _DRIVER = "sqlserver"
 
     def __init__(

--- a/src/databricks/labs/lakebridge/reconcile/constants.py
+++ b/src/databricks/labs/lakebridge/reconcile/constants.py
@@ -18,6 +18,7 @@ class ReconSourceType(AutoName):
     SNOWFLAKE = auto()
     ORACLE = auto()
     DATABRICKS = auto()
+    TSQL = auto()
 
 
 class ReconReportType(AutoName):

--- a/tests/unit/helpers/test_recon_config_utils.py
+++ b/tests/unit/helpers/test_recon_config_utils.py
@@ -64,7 +64,7 @@ def test_configure_secrets_oracle_insert(mock_workspace_client):
 def test_configure_secrets_invalid_source(mock_workspace_client):
     prompts = MockPrompts(
         {
-            r"Select the source": "3",
+            r"Select the source": "100",  # Invalid source
             r"Enter Secret Scope name": SCOPE_NAME,
         }
     )

--- a/tests/unit/reconcile/connectors/test_sql_server.py
+++ b/tests/unit/reconcile/connectors/test_sql_server.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, create_autospec
 import pytest
 
 from databricks.labs.lakebridge.transpiler.sqlglot.dialect_utils import get_dialect
-from databricks.labs.lakebridge.reconcile.connectors.sql_server import SQLServerDataSource
+from databricks.labs.lakebridge.reconcile.connectors.tsql import TSQLServerDataSource
 from databricks.labs.lakebridge.reconcile.exception import DataSourceRuntimeException
 from databricks.labs.lakebridge.reconcile.recon_config import JdbcReaderOptions, Table
 from databricks.sdk import WorkspaceClient
@@ -49,8 +49,8 @@ def initial_setup():
 def test_get_jdbc_url_happy():
     # initial setup
     engine, spark, ws, scope = initial_setup()
-    # create object for SnowflakeDataSource
-    data_source = SQLServerDataSource(engine, spark, ws, scope)
+    # create object for TSQLServerDataSource
+    data_source = TSQLServerDataSource(engine, spark, ws, scope)
     url = data_source.get_jdbc_url
     # Assert that the URL is generated correctly
     assert url == (
@@ -62,8 +62,8 @@ def test_get_jdbc_url_fail():
     # initial setup
     engine, spark, ws, scope = initial_setup()
     ws.secrets.get_secret.side_effect = mock_secret
-    # create object for SnowflakeDataSource
-    data_source = SQLServerDataSource(engine, spark, ws, scope)
+    # create object for TSQLServerDataSource
+    data_source = TSQLServerDataSource(engine, spark, ws, scope)
     url = data_source.get_jdbc_url
     # Assert that the URL is generated correctly
     assert url == (
@@ -75,8 +75,8 @@ def test_read_data_with_options():
     # initial setup
     engine, spark, ws, scope = initial_setup()
 
-    # create object for SnowflakeDataSource
-    data_source = SQLServerDataSource(engine, spark, ws, scope)
+    # create object for MSSQLServerDataSource
+    data_source = TSQLServerDataSource(engine, spark, ws, scope)
     # Create a Tables configuration object with JDBC reader options
     table_conf = Table(
         source_name="src_supplier",
@@ -117,7 +117,7 @@ def test_get_schema():
     # initial setup
     engine, spark, ws, scope = initial_setup()
     # Mocking get secret method to return the required values
-    data_source = SQLServerDataSource(engine, spark, ws, scope)
+    data_source = TSQLServerDataSource(engine, spark, ws, scope)
     # call test method
     data_source.get_schema("org", "schema", "supplier")
     # spark assertions
@@ -163,7 +163,7 @@ def test_get_schema():
 def test_get_schema_exception_handling():
     # initial setup
     engine, spark, ws, scope = initial_setup()
-    data_source = SQLServerDataSource(engine, spark, ws, scope)
+    data_source = TSQLServerDataSource(engine, spark, ws, scope)
 
     spark.read.format().option().option().option().option().load.side_effect = RuntimeError("Test Exception")
 


### PR DESCRIPTION
<!-- REMOVE IRRELEVANT COMMENTS BEFORE CREATING A PULL REQUEST -->
## Changes
<!-- Summary of your changes that are easy to understand. Add screenshots when necessary, they're helpful to illustrate the before and after state -->
### What does this PR do?

Enabled TSQL Recon while configure-reconcile


### Relevant implementation details

### Caveats/things to watch out for when reviewing:

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #..

### Functionality

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs lakebridge ...`
- [ ] ... +add your own

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
