### PR TITLE
Remove unused dependency: `databricks-labs-pytester`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,6 @@ dependencies = [
   "types-pyYAML~=6.0.12",
   "types-pytz~=2025.2",
   "databricks-labs-pylint~=0.4.0",
-  "databricks-labs-pytester>=0.3.0",
   "mypy~=1.10.0",
   "numpy==1.26.4",
   "pandas==1.4.1",


### PR DESCRIPTION
## Changes

### What does this PR do?

This PR removes a (test-time) dependency that isn't being used.

### Relevant implementation details

The `pytester` package is mainly used to provide fixtures that are useful when integration-testing against a live Databricks environment. Currently, however, we do not use it.

### Tests

- existing unit tests
- existing integration tests
