### PR TITLE
Fix `transpile` when relative path is given for input sources

### DIFF
--- a/src/databricks/labs/lakebridge/transpiler/lsp/lsp_engine.py
+++ b/src/databricks/labs/lakebridge/transpiler/lsp/lsp_engine.py
@@ -532,18 +532,18 @@ class LSPEngine(TranspileEngine):
 
     def open_document(self, file_path: Path, source_code: str) -> None:
         text_document = TextDocumentItem(
-            uri=file_path.as_uri(), language_id=LanguageKind.Sql, version=1, text=source_code
+            uri=file_path.absolute().as_uri(), language_id=LanguageKind.Sql, version=1, text=source_code
         )
         params = DidOpenTextDocumentParams(text_document)
         self._client.text_document_did_open(params)
 
     def close_document(self, file_path: Path) -> None:
-        text_document = TextDocumentIdentifier(uri=file_path.as_uri())
+        text_document = TextDocumentIdentifier(uri=file_path.absolute().as_uri())
         params = DidCloseTextDocumentParams(text_document)
         self._client.text_document_did_close(params)
 
     async def transpile_document(self, file_path: Path) -> TranspileDocumentResult:
-        params = TranspileDocumentParams(uri=file_path.as_uri(), language_id=LanguageKind.Sql)
+        params = TranspileDocumentParams(uri=file_path.absolute().as_uri(), language_id=LanguageKind.Sql)
         result = await self._client.transpile_document_async(params)
         return result
 

--- a/tests/resources/lsp_transpiler/lsp_server.py
+++ b/tests/resources/lsp_transpiler/lsp_server.py
@@ -135,9 +135,10 @@ class TestLspServer(LanguageServer):
         logger.debug(f"fetch-document-uri={uri}: {doc.source}")
 
     def transpile_to_databricks(self, params: TranspileDocumentParams) -> TranspileDocumentResult:
-        source_sql = self.workspace.get_text_document(params.uri).source
-        source_lines = source_sql.split("\n")
-        range = Range(start=Position(0, 0), end=Position(len(source_lines), len(source_lines[-1])))
+        document = self.workspace.get_text_document(params.uri)
+        line_count = len(document.lines)
+        source_sql = document.source
+        range = Range(start=Position(0, 0), end=Position(line_count, 0))
         transpiled_sql, diagnostics = self._transpile(Path(params.uri).name, range, source_sql)
         changes = [TextEdit(range=range, new_text=transpiled_sql)]
         return TranspileDocumentResult(

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -36,7 +36,7 @@ def mock_databricks_config():
 
 
 @pytest.fixture()
-def transpile_config():
+def transpile_config() -> Generator[TranspileConfig, None, None]:
     yield TranspileConfig(
         transpiler_config_path="sqlglot",
         transpiler_options={"-experimental": True},

--- a/tests/unit/transpiler/test_lsp_engine.py
+++ b/tests/unit/transpiler/test_lsp_engine.py
@@ -14,7 +14,7 @@ from databricks.labs.blueprint.wheels import ProductInfo
 
 from databricks.labs.lakebridge.config import TranspileConfig
 from databricks.labs.lakebridge.errors.exceptions import IllegalStateException
-from databricks.labs.lakebridge.transpiler.lsp.lsp_engine import ChangeManager, LSPEngine
+from databricks.labs.lakebridge.transpiler.lsp.lsp_engine import ChangeManager, LSPEngine, TranspileDocumentResult
 from databricks.labs.lakebridge.transpiler.transpile_status import TranspileError, ErrorSeverity, ErrorKind
 
 from tests.unit.conftest import path_to_resource
@@ -126,6 +126,26 @@ async def test_server_closes_document(lsp_engine: LSPEngine, transpile_config: T
     lsp_engine.close_document(sample_path)
     log = await read_log("close-document-uri")
     assert f"close-document-uri={sample_path.as_uri()}" in log
+
+
+async def test_server_transpiles_document(lsp_engine: LSPEngine, transpile_config: TranspileConfig) -> None:
+    """Test the simplest transpile workflow, where the LSP server reads a file from the filesystem."""
+    sample_path = Path(path_to_resource("lsp_transpiler", "source_stuff.sql"))
+    await lsp_engine.initialize(transpile_config)
+    # No need to open the document first, or close it afterwards: LSP server can read from filesystem.
+    result = await lsp_engine.transpile_document(sample_path)
+    await lsp_engine.shutdown()
+
+    sample_line_count = len(sample_path.read_text(encoding="utf-8").splitlines())
+    sample_whole_file_range = Range(Position(0, 0), Position(sample_line_count, 0))
+    expected_source = Path(path_to_resource("lsp_transpiler", "transpiled_stuff.sql")).read_text(encoding="utf-8")
+    expected_result = TranspileDocumentResult(
+        uri=sample_path.as_uri(),
+        language_id="sql",
+        diagnostics=[],
+        changes=[TextEdit(sample_whole_file_range, new_text=expected_source)],
+    )
+    assert result == expected_result
 
 
 async def test_server_transpiles_from_memory(lsp_engine: LSPEngine, transpile_config: TranspileConfig) -> None:

--- a/tests/unit/transpiler/test_lsp_engine.py
+++ b/tests/unit/transpiler/test_lsp_engine.py
@@ -128,13 +128,13 @@ async def test_server_closes_document(lsp_engine: LSPEngine, transpile_config: T
     assert f"close-document-uri={sample_path.as_uri()}" in log
 
 
-async def test_server_transpiles_document(lsp_engine: LSPEngine, transpile_config: TranspileConfig) -> None:
+async def test_server_transpiles_from_memory(lsp_engine: LSPEngine, transpile_config: TranspileConfig) -> None:
+    """Test the transpile workflow, where the LSP server is supplied an "open" file to transpile."""
     sample_path = Path(path_to_resource("lsp_transpiler", "source_stuff.sql"))
+    sample_code = sample_path.read_text(encoding="utf-8")
     await lsp_engine.initialize(transpile_config)
     assert (source_dialect := transpile_config.source_dialect) is not None
-    result = await lsp_engine.transpile(
-        source_dialect, "databricks", sample_path.read_text(encoding="utf-8"), sample_path
-    )
+    result = await lsp_engine.transpile(source_dialect, "databricks", sample_code, sample_path)
     await lsp_engine.shutdown()
     transpiled_path = Path(path_to_resource("lsp_transpiler", "transpiled_stuff.sql"))
     assert result.transpiled_code == transpiled_path.read_text(encoding="utf-8")

--- a/tests/unit/transpiler/test_lsp_engine.py
+++ b/tests/unit/transpiler/test_lsp_engine.py
@@ -128,11 +128,12 @@ async def test_server_closes_document(lsp_engine: LSPEngine, transpile_config: T
     assert f"close-document-uri={sample_path.as_uri()}" in log
 
 
-async def test_server_transpiles_document(lsp_engine, transpile_config):
+async def test_server_transpiles_document(lsp_engine: LSPEngine, transpile_config: TranspileConfig) -> None:
     sample_path = Path(path_to_resource("lsp_transpiler", "source_stuff.sql"))
     await lsp_engine.initialize(transpile_config)
+    assert (source_dialect := transpile_config.source_dialect) is not None
     result = await lsp_engine.transpile(
-        transpile_config.source_dialect, "databricks", sample_path.read_text(encoding="utf-8"), sample_path
+        source_dialect, "databricks", sample_path.read_text(encoding="utf-8"), sample_path
     )
     await lsp_engine.shutdown()
     transpiled_path = Path(path_to_resource("lsp_transpiler", "transpiled_stuff.sql"))

--- a/tests/unit/transpiler/test_lsp_engine.py
+++ b/tests/unit/transpiler/test_lsp_engine.py
@@ -14,6 +14,7 @@ from databricks.labs.blueprint.wheels import ProductInfo
 
 from databricks.labs.lakebridge.config import TranspileConfig
 from databricks.labs.lakebridge.errors.exceptions import IllegalStateException
+from databricks.labs.lakebridge.helpers.file_utils import chdir
 from databricks.labs.lakebridge.transpiler.lsp.lsp_engine import ChangeManager, LSPEngine, TranspileDocumentResult
 from databricks.labs.lakebridge.transpiler.transpile_status import TranspileError, ErrorSeverity, ErrorKind
 
@@ -156,6 +157,25 @@ async def test_server_transpiles_from_memory(lsp_engine: LSPEngine, transpile_co
     assert (source_dialect := transpile_config.source_dialect) is not None
     result = await lsp_engine.transpile(source_dialect, "databricks", sample_code, sample_path)
     await lsp_engine.shutdown()
+    transpiled_path = Path(path_to_resource("lsp_transpiler", "transpiled_stuff.sql"))
+    assert result.transpiled_code == transpiled_path.read_text(encoding="utf-8")
+
+
+async def test_server_transpiles_relative_path(lsp_engine: LSPEngine, transpile_config: TranspileConfig) -> None:
+    """Test the memory-based transpile workflow, specifying a relative path to transpile."""
+    sample_path = Path(path_to_resource("lsp_transpiler", "source_stuff.sql"))
+    sample_code = sample_path.read_text(encoding="utf-8")
+
+    run_from = sample_path.parent
+    relative_sample_path = sample_path.relative_to(run_from)
+    assert not relative_sample_path.is_absolute()
+
+    with chdir(run_from):
+        await lsp_engine.initialize(transpile_config)
+        assert (source_dialect := transpile_config.source_dialect) is not None
+        result = await lsp_engine.transpile(source_dialect, "databricks", sample_code, relative_sample_path)
+        await lsp_engine.shutdown()
+
     transpiled_path = Path(path_to_resource("lsp_transpiler", "transpiled_stuff.sql"))
     assert result.transpiled_code == transpiled_path.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Changes

This PR fixes transpiling input sources that are specified with a relative path (eg. `./a/directory`) instead of an absolute one.

Further to this, some tests were updated:

 - Minor cleanup of some existing tests. (Type-hinting, etc.)
 - A new test just for the custom `transpile_document` LSP call.

### Relevant implementation details

The fix for the bug being addressed was fairly straightforward.

The new test just for the custom `transpile_document` LSP call uncovered an off-by-one mistake in the stubbed LSP server. Although it was harmless, it was also fixed.

### Linked issues

Resolves #1837 

### Functionality

- modified existing command: `databricks labs lakebridge transpile`

### Tests

- manually tested
- added unit tests
