### PR TITLE
Improve end-to-end tests with non-UTF-8 sources

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,3 +17,12 @@ indent_size = tab
 
 [*.{json,yml}]
 indent_size = 2
+
+#
+# Some exceptions, in particular for tests.
+#
+[tests/resources/functional/informatica/wf_m_employees_load.XML]
+# Should be Windows-1252, but that's not allowed and we're using the common latin1 subset.
+charset = latin1
+end_of_line = crlf
+insert_final_newline = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -21,6 +21,8 @@ indent_size = 2
 #
 # Some exceptions, in particular for tests.
 #
+[tests/resources/functional/dbt/sub/sub-query-bom.sql]
+charset = utf-16le
 [tests/resources/functional/informatica/wf_m_employees_load.XML]
 # Should be Windows-1252, but that's not allowed and we're using the common latin1 subset.
 charset = latin1

--- a/.gitattributes
+++ b/.gitattributes
@@ -14,4 +14,5 @@
 *.whl -text
 
 # Specific test examples.
+tests/resources/functional/dbt/sub/sub-query-bom.sql              text working-tree-encoding=UTF-16
 tests/resources/functional/informatica/wf_m_employees_load.XML    text working-tree-encoding=WINDOWS-1252 eol=crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,17 @@
+#
+# Special attributes for files that aren't UTF-8, etc.
+#
+
+# Default settings.
+* text=auto eol=lf
+
+# Images in our documentation.
+*.gif -text
+*.png -text
+
+# Archives.
+*.jar -text
+*.whl -text
+
+# Specific test examples.
+tests/resources/functional/informatica/wf_m_employees_load.XML    text working-tree-encoding=WINDOWS-1252 eol=crlf

--- a/tests/integration/transpile/test_morpheus.py
+++ b/tests/integration/transpile/test_morpheus.py
@@ -38,4 +38,5 @@ async def _transpile_all_dbt_project_files(ws: WorkspaceClient, output_folder: P
     assert (output_folder / "top-query.sql").exists()
     assert (output_folder / "dbt_project.yml").exists()
     assert (output_folder / "sub" / "sub-query.sql").exists()
+    assert (output_folder / "sub" / "sub-query-bom.sql").exists()
     assert (output_folder / "sub" / "dbt_project.yml").exists()

--- a/tests/resources/functional/dbt/sub/sub-query-bom.sql
+++ b/tests/resources/functional/dbt/sub/sub-query-bom.sql
@@ -1,0 +1,2 @@
+-- This file is encoded in UTF-16, and has a BOM at the start.
+select * from {% employees %}

--- a/tests/resources/functional/informatica/wf_m_employees_load.XML
+++ b/tests/resources/functional/informatica/wf_m_employees_load.XML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="Windows-1252"?>
-<!-- This comment contains some chàráçterš that will trigger an error if this file is read as UTF-8. -->
+<!-- This comment contains some chÃ rÃ¡Ã§terÅ¡ that will trigger an error if this file is read as UTF-8. -->
 <!-- Informatica proprietary -->
 <!DOCTYPE POWERMART SYSTEM "powrmart.dtd">
 <POWERMART CREATION_DATE="06/05/2025 07:56:05" REPOSITORY_VERSION="189.98">


### PR DESCRIPTION
## Changes
### What does this PR do?

This PR improves the end-to-end integration tests that we perform with sources that are not UTF-8 encoded. This includes:

 - Morpheus: a SQL file encoded with UTF-16.

(A Bladebridge example is not included: it turns out this fails, and will be addressed in a subsequent PR.)

### Caveats/things to watch out for when reviewing:

Although it looks like there are changes to `wf_m_employees_load.XML`, there aren't really: it's a side-effect of configuring git to ensure the file has the encoding/line/file-ending that we intend. (Git prefers to store everything internally as UTF-8, and assumes files when checked out also are UTF-8… this PR configures git to encode the checked-out file properly.)

### Linked issues

Relates #63

### Tests

- updated integration tests
