### PR TITLE
LSP (client) test improvements

### DIFF
--- a/tests/unit/transpiler/test_lsp_engine.py
+++ b/tests/unit/transpiler/test_lsp_engine.py
@@ -93,6 +93,7 @@ async def test_server_has_transpile_capability(lsp_engine, transpile_config):
 
 
 async def read_log(marker: str) -> str:
+    # TODO: Fix this; logs should not be generated amongst the resources in our source tree.
     log_path = Path(path_to_resource("lsp_transpiler", "test-lsp-server.log"))
     # need to give time to child process
     for _ in range(1, 10):

--- a/tests/unit/transpiler/test_lsp_engine.py
+++ b/tests/unit/transpiler/test_lsp_engine.py
@@ -96,10 +96,10 @@ async def read_log(marker: str) -> str:
     log_path = Path(path_to_resource("lsp_transpiler", "test-lsp-server.log"))
     # need to give time to child process
     for _ in range(1, 10):
-        await asyncio.sleep(0.1)
         log = log_path.read_text("utf-8")
         if marker in log:
             break
+        await asyncio.sleep(0.1)
     return log_path.read_text("utf-8")
 
 

--- a/tests/unit/transpiler/test_lsp_engine.py
+++ b/tests/unit/transpiler/test_lsp_engine.py
@@ -4,7 +4,6 @@ import logging
 import os
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from time import sleep
 import pytest
 
 from lsprotocol.types import TextEdit, Range, Position
@@ -24,7 +23,6 @@ from tests.unit.conftest import path_to_resource
 async def test_initializes_lsp_server(lsp_engine, transpile_config):
     assert not lsp_engine.is_alive
     await lsp_engine.initialize(transpile_config)
-    sleep(3)
     assert lsp_engine.is_alive
 
 

--- a/tests/unit/transpiler/test_lsp_engine.py
+++ b/tests/unit/transpiler/test_lsp_engine.py
@@ -98,7 +98,7 @@ async def read_log(marker: str) -> str:
     for _ in range(1, 10):
         log = log_path.read_text("utf-8")
         if marker in log:
-            break
+            return log
         await asyncio.sleep(0.1)
     return log_path.read_text("utf-8")
 

--- a/tests/unit/transpiler/test_lsp_engine.py
+++ b/tests/unit/transpiler/test_lsp_engine.py
@@ -92,7 +92,7 @@ async def test_server_has_transpile_capability(lsp_engine, transpile_config):
     assert lsp_engine.server_has_transpile_capability
 
 
-async def read_log(marker: str):
+async def read_log(marker: str) -> str:
     log_path = Path(path_to_resource("lsp_transpiler", "test-lsp-server.log"))
     # need to give time to child process
     for _ in range(1, 10):

--- a/tests/unit/transpiler/test_lsp_engine.py
+++ b/tests/unit/transpiler/test_lsp_engine.py
@@ -20,6 +20,9 @@ from databricks.labs.lakebridge.transpiler.transpile_status import TranspileErro
 from tests.unit.conftest import path_to_resource
 
 
+# TODO: Arguably a form of integration test, as it round-trips with a real LSP server.
+
+
 async def test_initializes_lsp_server(lsp_engine, transpile_config):
     assert not lsp_engine.is_alive
     await lsp_engine.initialize(transpile_config)


### PR DESCRIPTION
## Changes
### What does this PR do?

This PR updates some of the tests for the LSP client. Changes include:

 - Removing some (unnecessary) delays.
 - When waiting for logs, avoid reading them an extra time after we know they're ready.
 - Some TODO markers for things to address.

### Linked issues

One of the TODO markers relates to one of the points in #1603.

### Tests

- updated unit tests
