### PR TITLE
Support snowflake `pem_private_key_password` and improve jdbc url args handling

### DIFF
--- a/docs/lakebridge/docs/reconcile/index.mdx
+++ b/docs/lakebridge/docs/reconcile/index.mdx
@@ -58,19 +58,24 @@ Below are the connection properties required for each source:
         ```yaml
         sfUrl = https://[acount_name].snowflakecomputing.com
         account = [acount_name]
-            sfUser = [user]
-            sfPassword = [password]
-            sfDatabase = [database]
-            sfSchema = [schema]
-            sfWarehouse = [warehouse_name]
-            sfRole = [role_name]
-            pem_private_key = [pkcs8_pem_private_key]
-            ```
-            :::note
-            For Snowflake authentication, either sfPassword or pem_private_key is required.
-            Priority is given to pem_private_key, and if it is not found, sfPassword will be used.
-            If neither is available, an exception will be raised.
-            :::
+        sfUser = [user]
+        sfPassword = [password]
+        sfDatabase = [database]
+        sfSchema = [schema]
+        sfWarehouse = [warehouse_name]
+        sfRole = [role_name]
+        pem_private_key = [pkcs8_pem_private_key]
+        pem_private_key_password = [pkcs8_pem_private_key]
+        ```
+
+        :::note
+        For Snowflake authentication, either sfPassword or pem_private_key is required.
+        Priority is given to pem_private_key, and if it is not found, sfPassword will be used.
+        If neither is available, an exception will be raised.
+
+        When using an encrypted pem_private_key, you'll need to provide the pem_private_key_password.
+        This password is used to decrypt the private key for authentication.
+        :::
     </TabItem>
     <TabItem value="oracle" label="Oracle">
         ```yaml

--- a/src/databricks/labs/lakebridge/reconcile/connectors/secrets.py
+++ b/src/databricks/labs/lakebridge/reconcile/connectors/secrets.py
@@ -11,8 +11,26 @@ class SecretsMixin:
     _ws: WorkspaceClient
     _secret_scope: str
 
+    def _get_secret_or_none(self, secret_key: str) -> str | None:
+        """
+        Get the secret value given a secret scope & secret key. Log a warning if secret does not exist
+        Used To ensure backwards compatibility when supporting new secrets
+        """
+        try:
+            # Return the decoded secret value in string format
+            return self._get_secret(secret_key)
+        except NotFound as e:
+            logger.warning(f"Secret not found: key={secret_key}")
+            logger.debug("Secret lookup failed", exc_info=e)
+            return None
+
     def _get_secret(self, secret_key: str) -> str:
-        """Get the secret value given a secret scope & secret key. Log a warning if secret does not exist"""
+        """Get the secret value given a secret scope & secret key.
+
+        Raises:
+          NotFound: The secret could not be found.
+          UnicodeDecodeError: The secret value was not Base64-encoded UTF-8.
+        """
         try:
             # Return the decoded secret value in string format
             secret = self._ws.secrets.get_secret(self._secret_scope, secret_key)

--- a/src/databricks/labs/lakebridge/reconcile/connectors/snowflake.py
+++ b/src/databricks/labs/lakebridge/reconcile/connectors/snowflake.py
@@ -79,7 +79,6 @@ class SnowflakeDataSource(DataSource, SecretsMixin, JDBCReaderMixin):
             f"&warehouse={self._get_secret('sfWarehouse')}&role={self._get_secret('sfRole')}"
         )
 
-
     def read_data(
         self,
         catalog: str | None,
@@ -152,7 +151,7 @@ class SnowflakeDataSource(DataSource, SecretsMixin, JDBCReaderMixin):
 
     def _get_snowflake_auth_options(self):
         try:
-            key = SnowflakeDataSource.get_private_key(
+            key = SnowflakeDataSource._get_private_key(
                 self._get_secret('pem_private_key'), self._get_secret_or_none('pem_private_key_password')
             )
             return {"pem_private_key": key}
@@ -167,7 +166,7 @@ class SnowflakeDataSource(DataSource, SecretsMixin, JDBCReaderMixin):
                 raise NotFound(message) from e
 
     @staticmethod
-    def get_private_key(pem_private_key: str, pem_private_key_password: str | None) -> str:
+    def _get_private_key(pem_private_key: str, pem_private_key_password: str | None) -> str:
         try:
             private_key_bytes = pem_private_key.encode("UTF-8")
             password_bytes = pem_private_key_password.encode("UTF-8") if pem_private_key_password else None

--- a/src/databricks/labs/lakebridge/reconcile/connectors/snowflake.py
+++ b/src/databricks/labs/lakebridge/reconcile/connectors/snowflake.py
@@ -79,30 +79,6 @@ class SnowflakeDataSource(DataSource, SecretsMixin, JDBCReaderMixin):
             f"&warehouse={self._get_secret('sfWarehouse')}&role={self._get_secret('sfRole')}"
         )
 
-    @staticmethod
-    def get_private_key(pem_private_key: str) -> str:
-        try:
-            private_key_bytes = pem_private_key.encode("UTF-8")
-            p_key = serialization.load_pem_private_key(
-                private_key_bytes,
-                password=None,
-                backend=default_backend(),
-            )
-            pkb = p_key.private_bytes(
-                encoding=serialization.Encoding.PEM,
-                format=serialization.PrivateFormat.PKCS8,
-                encryption_algorithm=serialization.NoEncryption(),
-            )
-            pkb_str = pkb.decode("UTF-8")
-            # Remove the first and last lines (BEGIN/END markers)
-            private_key_pem_lines = pkb_str.strip().split('\n')[1:-1]
-            # Join the lines to form the base64 encoded string
-            private_key_pem_str = ''.join(private_key_pem_lines)
-            return private_key_pem_str
-        except Exception as e:
-            message = f"Failed to load or process the provided PEM private key. --> {e}"
-            logger.error(message)
-            raise InvalidSnowflakePemPrivateKey(message) from e
 
     def read_data(
         self,
@@ -156,6 +132,12 @@ class SnowflakeDataSource(DataSource, SecretsMixin, JDBCReaderMixin):
             return self.log_and_throw_exception(e, "schema", schema_query)
 
     def reader(self, query: str) -> DataFrameReader:
+        options = self._get_snowflake_options()
+        return self._spark.read.format("snowflake").option("dbtable", f"({query}) as tmp").options(**options)
+
+    # TODO cache this method using @functools.cache
+    # Pay attention to https://pylint.pycqa.org/en/latest/user_guide/messages/warning/method-cache-max-size-none.html
+    def _get_snowflake_options(self):
         options = {
             "sfUrl": self._get_secret('sfUrl'),
             "sfUser": self._get_secret('sfUser'),
@@ -164,18 +146,57 @@ class SnowflakeDataSource(DataSource, SecretsMixin, JDBCReaderMixin):
             "sfWarehouse": self._get_secret('sfWarehouse'),
             "sfRole": self._get_secret('sfRole'),
         }
+        options = options | self._get_snowflake_auth_options()
+
+        return options
+
+    def _get_snowflake_auth_options(self):
         try:
-            options["pem_private_key"] = SnowflakeDataSource.get_private_key(self._get_secret('pem_private_key'))
+            key = SnowflakeDataSource.get_private_key(
+                self._get_secret('pem_private_key'), self._get_secret_or_none('pem_private_key_password')
+            )
+            return {"pem_private_key": key}
         except (NotFound, KeyError):
             logger.warning("pem_private_key not found. Checking for sfPassword")
             try:
-                options["sfPassword"] = self._get_secret('sfPassword')
+                password = self._get_secret('sfPassword')
+                return {"sfPassword": password}
             except (NotFound, KeyError) as e:
                 message = "sfPassword and pem_private_key not found. Either one is required for snowflake auth."
                 logger.error(message)
                 raise NotFound(message) from e
 
-        return self._spark.read.format("snowflake").option("dbtable", f"({query}) as tmp").options(**options)
+    @staticmethod
+    def get_private_key(pem_private_key: str, pem_private_key_password: str | None) -> str:
+        try:
+            private_key_bytes = pem_private_key.encode("UTF-8")
+            password_bytes = pem_private_key_password.encode("UTF-8") if pem_private_key_password else None
+        except UnicodeEncodeError as e:
+            message = f"Invalid pem key and/or pem password: unable to encode. --> {e}"
+            logger.error(message)
+            raise ValueError(message) from e
+
+        try:
+            p_key = serialization.load_pem_private_key(
+                private_key_bytes,
+                password_bytes,
+                backend=default_backend(),
+            )
+            pkb = p_key.private_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PrivateFormat.PKCS8,
+                encryption_algorithm=serialization.NoEncryption(),
+            )
+            pkb_str = pkb.decode("UTF-8")
+            # Remove the first and last lines (BEGIN/END markers)
+            private_key_pem_lines = pkb_str.strip().split('\n')[1:-1]
+            # Join the lines to form the base64 encoded string
+            private_key_pem_str = ''.join(private_key_pem_lines)
+            return private_key_pem_str
+        except Exception as e:
+            message = f"Failed to load or process the provided PEM private key. --> {e}"
+            logger.error(message)
+            raise InvalidSnowflakePemPrivateKey(message) from e
 
     def normalize_identifier(self, identifier: str) -> NormalizedIdentifier:
         return DialectUtils.normalize_identifier(

--- a/tests/unit/reconcile/connectors/test_snowflake.py
+++ b/tests/unit/reconcile/connectors/test_snowflake.py
@@ -60,12 +60,16 @@ def generate_pkcs8_pem_key(malformed=False):
 def mock_private_key_secret(scope, key):
     if key == 'pem_private_key':
         return GetSecretResponse(key=key, value=base64.b64encode(generate_pkcs8_pem_key().encode()).decode())
+    if key == 'pem_private_key_password':
+        return GetSecretResponse(key=key, value=b''.decode())
     return mock_secret(scope, key)
 
 
 def mock_malformed_private_key_secret(scope, key):
     if key == 'pem_private_key':
         return GetSecretResponse(key=key, value=base64.b64encode(generate_pkcs8_pem_key(True).encode()).decode())
+    if key == 'pem_private_key_password':
+        return GetSecretResponse(key=key, value=b''.decode())
     return mock_secret(scope, key)
 
 
@@ -272,7 +276,7 @@ def test_get_schema_exception_handling():
         dfds.get_schema("catalog", "schema", "supplier")
 
 
-def test_read_data_with_out_options_private_key():
+def test_read_data_without_options_private_key():
     engine, spark, ws, scope = initial_setup()
     ws.secrets.get_secret.side_effect = mock_private_key_secret
     dfds = SnowflakeDataSource(engine, spark, ws, scope)
@@ -294,7 +298,7 @@ def test_read_data_with_out_options_private_key():
     spark.read.format().option().options().load.assert_called_once()
 
 
-def test_read_data_with_out_options_malformed_private_key():
+def test_read_data_without_options_malformed_private_key():
     engine, spark, ws, scope = initial_setup()
     ws.secrets.get_secret.side_effect = mock_malformed_private_key_secret
     dfds = SnowflakeDataSource(engine, spark, ws, scope)
@@ -303,7 +307,7 @@ def test_read_data_with_out_options_malformed_private_key():
         dfds.read_data("org", "data", "employee", "select 1 from :tbl", table_conf.jdbc_reader_options)
 
 
-def test_read_data_with_out_any_auth():
+def test_read_data_without_any_auth():
     engine, spark, ws, scope = initial_setup()
     ws.secrets.get_secret.side_effect = mock_no_auth_key_secret
     dfds = SnowflakeDataSource(engine, spark, ws, scope)


### PR DESCRIPTION
<!-- REMOVE IRRELEVANT COMMENTS BEFORE CREATING A PULL REQUEST -->
## Changes
<!-- Summary of your changes that are easy to understand. Add screenshots when necessary, they're helpful to illustrate the before and after state -->
### What does this PR do?
Makes it possible to add a snowflake pem key password to decrypt snowflake pem keys when reading
### Relevant implementation details

### Caveats/things to watch out for when reviewing:

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #1747 
Resolves #1748

### Functionality

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs lakebridge ...`
- [ ] ... +add your own

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [X] added unit tests
- [ ] added integration tests
