### PR TITLE
CI update: run acceptance tests even if PR is in draft mode

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -2,7 +2,7 @@ name: acceptance
 
 on:
   pull_request:
-    types: [ opened, synchronize, ready_for_review ]
+    types: [ opened, synchronize ]
   merge_group:
     types: [ checks_requested ]
   push:


### PR DESCRIPTION
## Changes

### What does this PR do?

Prior to this PR, CI does not run the integration tests while a PR is in _Draft_ mode. This PR updates the CI configuration so we always run the integration tests, even if the PR is in _Draft_ mode. This is intended to improve things:

 - Less noise with draft/do-not-merge changes just to trigger the CI-based integration tests.
 - Problems with integration tests can be discovered while a PR is being worked on rather than after it's been marked as ready for review.
