### PR TITLE
Remove spurious warning during fresh `install-transpile`

### DIFF
--- a/src/databricks/labs/lakebridge/deployment/installation.py
+++ b/src/databricks/labs/lakebridge/deployment/installation.py
@@ -61,7 +61,7 @@ class WorkspaceInstallation:
         try:
             return self._installation.load(Version)
         except ResourceDoesNotExist:
-            logger.debug(f"No existing version found in workspace; assuming fresh installation.")
+            logger.debug("No existing version found in workspace; assuming fresh installation.")
             return None
 
     def _apply_upgrades(self):

--- a/src/databricks/labs/lakebridge/deployment/installation.py
+++ b/src/databricks/labs/lakebridge/deployment/installation.py
@@ -60,8 +60,8 @@ class WorkspaceInstallation:
     def _get_ws_version(self):
         try:
             return self._installation.load(Version)
-        except ResourceDoesNotExist as err:
-            logger.warning(f"Unable to get Workspace Version due to: {err}")
+        except ResourceDoesNotExist:
+            logger.debug(f"No existing version found in workspace; assuming fresh installation.")
             return None
 
     def _apply_upgrades(self):


### PR DESCRIPTION
## Changes

This is a small PR that removes an unnecessary warning that was triggered during the first `install-transpile` because it couldn't locate the existing version. This is a normal situation, and therefore does not warrant a warning.

Prior to this PR:
```
14:15:39    DEBUG [d.l.blueprint.installation] Loading Version from version.json
14:15:39    DEBUG [databricks.sdk] GET /api/2.0/workspace/export?path=/Users/**REDACTED**@databricks.com/.lakebridge/version.json&direct_download=true
< 404 Not Found
< {
<   "error_code": "RESOURCE_DOES_NOT_EXIST",
<   "message": "Path (/Users/**REDACTED**/.lakebridge/version.json) doesn't exist."
< }
14:15:39  WARNING [d.l.lakebridge.install] Unable to get Workspace Version due to: Path (/Users/**REDACTED**@databricks.com/.lakebridge/version.json) doesn't exist.
```

After this PR:
```
14:51:22    DEBUG [databricks.sdk] GET /api/2.0/workspace/export?path=/Users/**REDACTED**@databricks.com/.lakebridge/version.json&direct_download=true
< 404 Not Found
< {
<   "error_code": "RESOURCE_DOES_NOT_EXIST",
<   "message": "Path (/Users/**REDACTED**/.lakebridge/version.json) doesn't exist."
< }
14:51:22    DEBUG [d.l.lakebridge.install] No existing version found in workspace; assuming fresh installation.
```

### Functionality

- modified existing command: `databricks labs lakebridge install-transpile`

### Tests

- manually tested
