### PR TITLE
Refactor transpiler repository

### DIFF
--- a/src/databricks/labs/lakebridge/cli.py
+++ b/src/databricks/labs/lakebridge/cli.py
@@ -32,14 +32,13 @@ from databricks.labs.lakebridge.config import TranspileConfig
 from databricks.labs.lakebridge.contexts.application import ApplicationContext
 from databricks.labs.lakebridge.helpers.recon_config_utils import ReconConfigPrompts
 from databricks.labs.lakebridge.helpers.telemetry_utils import make_alphanum_or_semver
-from databricks.labs.lakebridge.install import WorkspaceInstaller, TranspilerRepository
+from databricks.labs.lakebridge.install import WorkspaceInstaller
 from databricks.labs.lakebridge.reconcile.runner import ReconcileRunner
 from databricks.labs.lakebridge.lineage import lineage_generator
 from databricks.labs.lakebridge.reconcile.recon_config import RECONCILE_OPERATION_NAME, AGG_RECONCILE_OPERATION_NAME
 from databricks.labs.lakebridge.transpiler.execute import transpile as do_transpile
-
-
 from databricks.labs.lakebridge.transpiler.lsp.lsp_engine import LSPEngine
+from databricks.labs.lakebridge.transpiler.repository import TranspilerRepository
 from databricks.labs.lakebridge.transpiler.sqlglot.sqlglot_engine import SqlglotEngine
 from databricks.labs.lakebridge.transpiler.transpile_engine import TranspileEngine
 

--- a/src/databricks/labs/lakebridge/install.py
+++ b/src/databricks/labs/lakebridge/install.py
@@ -1,10 +1,7 @@
-from __future__ import annotations
-
 import re
 import abc
 import dataclasses
 import shutil
-from collections.abc import Iterable
 from json import loads, dump
 import logging
 import os
@@ -34,128 +31,16 @@ from databricks.labs.lakebridge.config import (
     DatabaseConfig,
     LakebridgeConfiguration,
     ReconcileMetadataConfig,
-    LSPConfigOptionV1,
 )
-
 from databricks.labs.lakebridge.deployment.configurator import ResourceConfigurator
 from databricks.labs.lakebridge.deployment.installation import WorkspaceInstallation
 from databricks.labs.lakebridge.helpers.file_utils import chdir
 from databricks.labs.lakebridge.reconcile.constants import ReconReportType, ReconSourceType
-from databricks.labs.lakebridge.transpiler.lsp.lsp_engine import LSPConfig
+from databricks.labs.lakebridge.transpiler.repository import TranspilerRepository
 
 logger = logging.getLogger(__name__)
 
 TRANSPILER_WAREHOUSE_PREFIX = "Lakebridge Transpiler Validation"
-
-
-# TODO: Move this into a separate module.
-class TranspilerRepository:
-    """
-    Repository for managing the installed transpilers in the user's home directory.
-
-    The default repository for a user is always located under ~/.databricks/labs, and can be obtained
-    via the `TranspilerRepository.user_home()` method.
-    """
-
-    @staticmethod
-    def default_labs_path() -> Path:
-        """Return the default path where labs applications are installed."""
-        return Path.home() / ".databricks" / "labs"
-
-    _default_repository: TranspilerRepository | None = None
-
-    @classmethod
-    def user_home(cls) -> TranspilerRepository:
-        """The default repository for transpilers in the current user's home directory."""
-        repository = cls._default_repository
-        if repository is None:
-            cls._default_repository = repository = cls(cls.default_labs_path())
-        return repository
-
-    def __init__(self, labs_path: Path) -> None:
-        """Initialize the repository, based in the given location.
-
-        This should only be used directly by tests; for the default repository, use `TranspilerRepository.user_home()`.
-
-        Args:
-            labs_path: The path where the labs applications are installed.
-        """
-        if self._default_repository == self and labs_path == self.default_labs_path():
-            raise ValueError("Use TranspilerRepository.user_home() to get the default repository.")
-        self._labs_path = labs_path
-
-    def __repr__(self) -> str:
-        return f"TranspilerRepository(labs_path={self._labs_path!r})"
-
-    def transpilers_path(self) -> Path:
-        return self._labs_path / "remorph-transpilers"
-
-    def get_installed_version(self, product_name: str) -> str | None:
-        # Warning: product_name here (eg. 'morpheus') and transpiler_name elsewhere (eg. Morpheus) are not the same!
-        product_path = self.transpilers_path() / product_name
-        current_version_path = product_path / "state" / "version.json"
-        if not current_version_path.exists():
-            return None
-        text = current_version_path.read_text("utf-8")
-        data: dict[str, Any] = loads(text)
-        version: str | None = data.get("version", None)
-        if not version or not version.startswith("v"):
-            return None
-        return version[1:]
-
-    def all_transpiler_configs(self) -> dict[str, LSPConfig]:
-        all_configs = self._all_transpiler_configs()
-        return {config.name: config for config in all_configs}
-
-    def all_transpiler_names(self) -> set[str]:
-        all_configs = self.all_transpiler_configs()
-        return set(all_configs.keys())
-
-    def all_dialects(self) -> set[str]:
-        all_dialects: set[str] = set()
-        for config in self._all_transpiler_configs():
-            all_dialects = all_dialects.union(config.remorph.dialects)
-        return all_dialects
-
-    def transpilers_with_dialect(self, dialect: str) -> set[str]:
-        configs = filter(lambda cfg: dialect in cfg.remorph.dialects, self.all_transpiler_configs().values())
-        return set(config.name for config in configs)
-
-    def transpiler_config_path(self, transpiler_name: str) -> Path:
-        # Note: Can't just go straight to the directory: the transpiler names don't exactly match the directory names.
-        try:
-            config = next(c for c in self._all_transpiler_configs() if c.name == transpiler_name)
-        except StopIteration as e:
-            raise ValueError(f"No such transpiler: {transpiler_name}") from e
-        return config.path
-
-    def transpiler_config_options(self, transpiler_name: str, source_dialect: str) -> list[LSPConfigOptionV1]:
-        config = self.all_transpiler_configs().get(transpiler_name, None)
-        if not config:
-            return []  # gracefully returns an empty list, since this can only happen during testing
-        return config.options_for_dialect(source_dialect)
-
-    def _all_transpiler_configs(self) -> Iterable[LSPConfig]:
-        transpilers_path = self.transpilers_path()
-        if transpilers_path.exists():
-            all_files = os.listdir(transpilers_path)
-            for file in all_files:
-                config = self._transpiler_config(transpilers_path / file)
-                if config:
-                    yield config
-
-    @classmethod
-    def _transpiler_config(cls, path: Path) -> LSPConfig | None:
-        if not path.is_dir() or not (path / "lib").is_dir():
-            return None
-        config_path = path / "lib" / "config.yml"
-        if not config_path.is_file():
-            return None
-        try:
-            return LSPConfig.load(config_path)
-        except ValueError as e:
-            logger.error(f"Could not load config: {path!s}", exc_info=e)
-            return None
 
 
 class TranspilerInstaller(abc.ABC):

--- a/src/databricks/labs/lakebridge/transpiler/repository.py
+++ b/src/databricks/labs/lakebridge/transpiler/repository.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from json import loads
+import logging
+import os
+from typing import Any
+from pathlib import Path
+
+from databricks.labs.lakebridge.config import LSPConfigOptionV1
+
+from databricks.labs.lakebridge.transpiler.lsp.lsp_engine import LSPConfig
+
+logger = logging.getLogger(__name__)
+
+
+class TranspilerRepository:
+    """
+    Repository for managing the installed transpilers in the user's home directory.
+
+    The default repository for a user is always located under ~/.databricks/labs, and can be obtained
+    via the `TranspilerRepository.user_home()` method.
+    """
+
+    @staticmethod
+    def default_labs_path() -> Path:
+        """Return the default path where labs applications are installed."""
+        return Path.home() / ".databricks" / "labs"
+
+    _default_repository: TranspilerRepository | None = None
+
+    @classmethod
+    def user_home(cls) -> TranspilerRepository:
+        """The default repository for transpilers in the current user's home directory."""
+        repository = cls._default_repository
+        if repository is None:
+            cls._default_repository = repository = cls(cls.default_labs_path())
+        return repository
+
+    def __init__(self, labs_path: Path) -> None:
+        """Initialize the repository, based in the given location.
+
+        This should only be used directly by tests; for the default repository, use `TranspilerRepository.user_home()`.
+
+        Args:
+            labs_path: The path where the labs applications are installed.
+        """
+        if self._default_repository == self and labs_path == self.default_labs_path():
+            raise ValueError("Use TranspilerRepository.user_home() to get the default repository.")
+        self._labs_path = labs_path
+
+    def __repr__(self) -> str:
+        return f"TranspilerRepository(labs_path={self._labs_path!r})"
+
+    def transpilers_path(self) -> Path:
+        return self._labs_path / "remorph-transpilers"
+
+    def get_installed_version(self, product_name: str) -> str | None:
+        # Warning: product_name here (eg. 'morpheus') and transpiler_name elsewhere (eg. Morpheus) are not the same!
+        product_path = self.transpilers_path() / product_name
+        current_version_path = product_path / "state" / "version.json"
+        if not current_version_path.exists():
+            return None
+        text = current_version_path.read_text("utf-8")
+        data: dict[str, Any] = loads(text)
+        version: str | None = data.get("version", None)
+        if not version or not version.startswith("v"):
+            return None
+        return version[1:]
+
+    def all_transpiler_configs(self) -> dict[str, LSPConfig]:
+        all_configs = self._all_transpiler_configs()
+        return {config.name: config for config in all_configs}
+
+    def all_transpiler_names(self) -> set[str]:
+        all_configs = self.all_transpiler_configs()
+        return set(all_configs.keys())
+
+    def all_dialects(self) -> set[str]:
+        all_dialects: set[str] = set()
+        for config in self._all_transpiler_configs():
+            all_dialects = all_dialects.union(config.remorph.dialects)
+        return all_dialects
+
+    def transpilers_with_dialect(self, dialect: str) -> set[str]:
+        configs = filter(lambda cfg: dialect in cfg.remorph.dialects, self.all_transpiler_configs().values())
+        return set(config.name for config in configs)
+
+    def transpiler_config_path(self, transpiler_name: str) -> Path:
+        # Note: Can't just go straight to the directory: the transpiler names don't exactly match the directory names.
+        try:
+            config = next(c for c in self._all_transpiler_configs() if c.name == transpiler_name)
+        except StopIteration as e:
+            raise ValueError(f"No such transpiler: {transpiler_name}") from e
+        return config.path
+
+    def transpiler_config_options(self, transpiler_name: str, source_dialect: str) -> list[LSPConfigOptionV1]:
+        config = self.all_transpiler_configs().get(transpiler_name, None)
+        if not config:
+            return []  # gracefully returns an empty list, since this can only happen during testing
+        return config.options_for_dialect(source_dialect)
+
+    def _all_transpiler_configs(self) -> Iterable[LSPConfig]:
+        transpilers_path = self.transpilers_path()
+        if transpilers_path.exists():
+            all_files = os.listdir(transpilers_path)
+            for file in all_files:
+                config = self._transpiler_config(transpilers_path / file)
+                if config:
+                    yield config
+
+    @classmethod
+    def _transpiler_config(cls, path: Path) -> LSPConfig | None:
+        if not path.is_dir() or not (path / "lib").is_dir():
+            return None
+        config_path = path / "lib" / "config.yml"
+        if not config_path.is_file():
+            return None
+        try:
+            return LSPConfig.load(config_path)
+        except ValueError as e:
+            logger.error(f"Could not load config: {path!s}", exc_info=e)
+            return None

--- a/tests/integration/install/test_install_and_run.py
+++ b/tests/integration/install/test_install_and_run.py
@@ -8,8 +8,9 @@ from email.parser import Parser as EmailParser
 import pytest
 
 from databricks.labs.lakebridge.config import TranspileConfig, TranspileResult
-from databricks.labs.lakebridge.install import TranspilerRepository, WheelInstaller, MavenInstaller
+from databricks.labs.lakebridge.install import WheelInstaller, MavenInstaller
 from databricks.labs.lakebridge.transpiler.lsp.lsp_engine import LSPEngine
+from databricks.labs.lakebridge.transpiler.repository import TranspilerRepository
 from databricks.labs.lakebridge.transpiler.transpile_engine import TranspileEngine
 
 

--- a/tests/integration/install/test_installer.py
+++ b/tests/integration/install/test_installer.py
@@ -4,7 +4,8 @@ from pathlib import Path
 
 import pytest
 
-from databricks.labs.lakebridge.install import MavenInstaller, TranspilerRepository, WheelInstaller, WorkspaceInstaller
+from databricks.labs.lakebridge.install import MavenInstaller, WheelInstaller, WorkspaceInstaller
+from databricks.labs.lakebridge.transpiler.repository import TranspilerRepository
 
 # TODO: These should run as part of the integration tests, not a separate test suite.
 

--- a/tests/integration/install/test_installer.py
+++ b/tests/integration/install/test_installer.py
@@ -1,28 +1,10 @@
-import shutil
-from collections.abc import Generator
 from pathlib import Path
 
 import pytest
 
 from databricks.labs.lakebridge.install import MavenInstaller, WheelInstaller, WorkspaceInstaller
-from databricks.labs.lakebridge.transpiler.repository import TranspilerRepository
 
 # TODO: These should run as part of the integration tests, not a separate test suite.
-
-
-@pytest.fixture()
-def transpiler_repository(tmp_path: Path) -> Generator[TranspilerRepository, None, None]:
-    resources_folder = Path(__file__).parent.parent.parent / "resources" / "transpiler_configs"
-    labs_path = tmp_path / "labs"
-    repository = TranspilerRepository(labs_path=labs_path)
-    for transpiler in ("bladebridge", "morpheus"):
-        install_directory = repository.transpilers_path() / transpiler / "lib"
-        install_directory.mkdir(parents=True)
-        source = resources_folder / transpiler / "lib" / "config.yml"
-        target = install_directory / "config.yml"
-        # Just the config file, not the whole thing: we're only testing the repository and transpiler metadata.
-        shutil.copyfile(source, target)
-    yield repository
 
 
 def test_gets_maven_artifact_version() -> None:
@@ -45,37 +27,6 @@ def test_gets_pypi_artifact_version() -> None:
     version = WheelInstaller.get_latest_artifact_version_from_pypi("databricks-labs-remorph")
     assert version is not None
     check_valid_version(version)
-
-
-def test_lists_all_transpiler_names(transpiler_repository: TranspilerRepository) -> None:
-    transpiler_names = transpiler_repository.all_transpiler_names()
-    assert transpiler_names == {'Morpheus', 'Bladebridge'}
-
-
-def test_lists_all_dialects(transpiler_repository: TranspilerRepository) -> None:
-    dialects = transpiler_repository.all_dialects()
-    assert dialects == {
-        'athena',
-        'bigquery',
-        'datastage',
-        'greenplum',
-        'informatica (desktop edition)',
-        'mssql',
-        'netezza',
-        'oracle',
-        'redshift',
-        'snowflake',
-        'synapse',
-        'teradata',
-        'tsql',
-    }
-
-
-def test_lists_dialect_transpilers(transpiler_repository: TranspilerRepository) -> None:
-    transpilers = transpiler_repository.transpilers_with_dialect("snowflake")
-    assert transpilers == {'Morpheus', 'Bladebridge'}
-    transpilers = transpiler_repository.transpilers_with_dialect("datastage")
-    assert transpilers == {'Bladebridge'}
 
 
 def check_valid_version(version: str) -> None:

--- a/tests/integration/transpile/test_bladebridge.py
+++ b/tests/integration/transpile/test_bladebridge.py
@@ -5,8 +5,9 @@ from pathlib import Path
 from databricks.sdk import WorkspaceClient
 
 from databricks.labs.lakebridge.config import TranspileConfig
-from databricks.labs.lakebridge.install import TranspilerRepository, WheelInstaller
+from databricks.labs.lakebridge.install import WheelInstaller
 from databricks.labs.lakebridge.transpiler.execute import transpile
+from databricks.labs.lakebridge.transpiler.repository import TranspilerRepository
 from databricks.labs.lakebridge.transpiler.transpile_engine import TranspileEngine
 
 logger = logging.getLogger(__name__)

--- a/tests/integration/transpile/test_morpheus.py
+++ b/tests/integration/transpile/test_morpheus.py
@@ -3,8 +3,9 @@ from pathlib import Path
 from databricks.sdk import WorkspaceClient
 
 from databricks.labs.lakebridge.config import TranspileConfig
-from databricks.labs.lakebridge.install import TranspilerRepository, MavenInstaller
+from databricks.labs.lakebridge.install import MavenInstaller
 from databricks.labs.lakebridge.transpiler.execute import transpile
+from databricks.labs.lakebridge.transpiler.repository import TranspilerRepository
 from databricks.labs.lakebridge.transpiler.transpile_engine import TranspileEngine
 
 

--- a/tests/integration/transpile/test_repository.py
+++ b/tests/integration/transpile/test_repository.py
@@ -1,0 +1,54 @@
+import shutil
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+
+from databricks.labs.lakebridge.transpiler.repository import TranspilerRepository
+
+
+@pytest.fixture
+def transpiler_repository(tmp_path: Path) -> Generator[TranspilerRepository, None, None]:
+    """A thin transpiler repository that only contains metadata for the Bladebridge and Morpheus transpilers."""
+    resources_folder = Path(__file__).parent.parent.parent / "resources" / "transpiler_configs"
+    labs_path = tmp_path / "labs"
+    repository = TranspilerRepository(labs_path=labs_path)
+    for transpiler in ("bladebridge", "morpheus"):
+        install_directory = repository.transpilers_path() / transpiler / "lib"
+        install_directory.mkdir(parents=True)
+        source = resources_folder / transpiler / "lib" / "config.yml"
+        target = install_directory / "config.yml"
+        # Just the config file, not the whole thing: we're only testing the repository and transpiler metadata.
+        shutil.copyfile(source, target)
+    yield repository
+
+
+def test_lists_all_transpiler_names(transpiler_repository: TranspilerRepository) -> None:
+    transpiler_names = transpiler_repository.all_transpiler_names()
+    assert transpiler_names == {'Morpheus', 'Bladebridge'}
+
+
+def test_lists_all_dialects(transpiler_repository: TranspilerRepository) -> None:
+    dialects = transpiler_repository.all_dialects()
+    assert dialects == {
+        'athena',
+        'bigquery',
+        'datastage',
+        'greenplum',
+        'informatica (desktop edition)',
+        'mssql',
+        'netezza',
+        'oracle',
+        'redshift',
+        'snowflake',
+        'synapse',
+        'teradata',
+        'tsql',
+    }
+
+
+def test_lists_dialect_transpilers(transpiler_repository: TranspilerRepository) -> None:
+    transpilers = transpiler_repository.transpilers_with_dialect("snowflake")
+    assert transpilers == {'Morpheus', 'Bladebridge'}
+    transpilers = transpiler_repository.transpilers_with_dialect("datastage")
+    assert transpilers == {'Bladebridge'}

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -26,6 +26,7 @@ from databricks.labs.lakebridge.deployment.configurator import ResourceConfigura
 from databricks.labs.lakebridge.deployment.installation import WorkspaceInstallation
 from databricks.labs.lakebridge.install import WorkspaceInstaller, TranspilerInstaller
 from databricks.labs.lakebridge.reconcile.constants import ReconSourceType, ReconReportType
+from databricks.labs.lakebridge.transpiler.repository import TranspilerRepository
 
 from tests.unit.conftest import path_to_resource
 

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -11,20 +11,20 @@ from databricks.labs.blueprint.installation import MockInstallation
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.service import iam
 from databricks.labs.blueprint.tui import MockPrompts
+from databricks.labs.blueprint.wheels import ProductInfo, WheelsV2
 from databricks.labs.lakebridge.config import (
-    LakebridgeConfiguration,
-    ReconcileConfig,
     DatabaseConfig,
-    ReconcileMetadataConfig,
     LSPConfigOptionV1,
     LSPPromptMethod,
+    LakebridgeConfiguration,
+    ReconcileConfig,
+    ReconcileMetadataConfig,
+    TranspileConfig,
 )
 from databricks.labs.lakebridge.contexts.application import ApplicationContext
 from databricks.labs.lakebridge.deployment.configurator import ResourceConfigurator
 from databricks.labs.lakebridge.deployment.installation import WorkspaceInstallation
-from databricks.labs.lakebridge.install import WorkspaceInstaller, TranspilerInstaller, TranspilerRepository
-from databricks.labs.lakebridge.config import TranspileConfig
-from databricks.labs.blueprint.wheels import ProductInfo, WheelsV2
+from databricks.labs.lakebridge.install import WorkspaceInstaller, TranspilerInstaller
 from databricks.labs.lakebridge.reconcile.constants import ReconSourceType, ReconReportType
 
 from tests.unit.conftest import path_to_resource


### PR DESCRIPTION
## Changes

Following from #1861, this PR splits out `TranspilerRepository` into its own module.

### Caveats/things to watch out for when reviewing

The scope of this PR is limited to moving the code.

### Linked issues

Follows: #1861

### Tests

- existing (and updated) integration tests
