### PR TITLE
Fix semi-broken unit tests on `main` for `installer.py`

### DIFF
--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -55,6 +55,20 @@ PATH_TO_TRANSPILER_CONFIG = "/some/path/to/config.yml"
 def ws_installer() -> Generator[Callable[..., WorkspaceInstaller], None, None]:
 
     class TestWorkspaceInstaller(WorkspaceInstaller):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            # Ensure that the transpiler repository is mocked for unit tests instead of being the real thing.
+            if self._transpiler_repository == TranspilerRepository.user_home():
+                self._transpiler_repository = create_autospec(TranspilerRepository)
+
+        def install_bladebridge(self, artifact: Path | None = None) -> None:
+            # Ensure that unit tests do not attempt to install BladeBridge
+            pass
+
+        def install_morpheus(self, artifact: Path | None = None) -> None:
+            # Ensure that unit tests do not attempt to install Morpheus
+            pass
+
         def _all_installed_dialects(self):
             return ALL_INSTALLED_DIALECTS_NO_LATER
 


### PR DESCRIPTION
## Changes

This PR updates the fixture used by the installer unit tests, fixing an error introduced in #1861 whereby it accesses (and modifies) the user's `~/.databricks/labs/remorph-transpilers`. As a unit test, it should do this. Coincidentally the tests pass if there is nothing installed in that location, but can fail if there is. 

### Linked issues

Follows #1861

### Tests

- fixed unit tests
