### PR TITLE
Add DuckDB Table Validator

### DIFF
--- a/src/databricks/labs/lakebridge/assessments/profiler_validator.py
+++ b/src/databricks/labs/lakebridge/assessments/profiler_validator.py
@@ -1,0 +1,93 @@
+from typing import List
+from dataclasses import dataclass
+from pyspark.sql import (SparkSession, DataFrame)
+from duckdb import DuckDBPyConnection
+
+
+@dataclass(frozen=True)
+class ValidationOutcome:
+    """A data class that holds the outcome of a table validation check."""
+    table: str
+    column: str | None
+    strategy: str
+    outcome: str
+    severity: str
+
+
+class ValidationStrategy:
+    """Abstract class for validating a Profiler table"""
+
+    def validate(self, connection: DuckDBPyConnection) -> ValidationOutcome:
+        raise NotImplementedError
+
+
+class NullValidationCheck(ValidationStrategy):
+    """Concrete class for validating null values in a profiler table"""
+
+    def __init__(self, table, column, severity="WARN"):
+        self.name = self.__class__.__name__
+        self.table = table
+        self.column = column
+        self.severity = severity
+
+    def validate(self, connection: DuckDBPyConnection) -> ValidationOutcome:
+        """
+        Validates that a column does not contain null values.
+        input:
+          connection: a DuckDB connection object
+        """
+        row_count = connection.execute(f"SELECT COUNT(*) FROM {self.table} WHERE {self.column} IS NULL").fetchone()[0]
+        outcome = "PASS" if row_count > 0 else "FAIL"
+        return ValidationOutcome(self.table, self.column, self.name, outcome, self.severity)
+
+
+class EmptyTableValidationCheck(ValidationStrategy):
+    """Concrete class for validating empty tables from a profiler run."""
+
+    def __init__(self, table, severity="WARN"):
+        self.name = self.__class__.__name__
+        self.table = table
+        self.severity = severity
+
+    def validate(self, connection) -> ValidationOutcome:
+        """Validates that a table is not empty.
+        input:
+          connection: a DuckDB connection object
+        returns:
+          a ValidationOutcome object
+        """
+        row_count = connection.execute(f"SELECT COUNT(*) FROM {self.table}").fetchone()[0]
+        outcome = "PASS" if row_count > 0 else "FAIL"
+        return ValidationOutcome(self.table, None, self.name, outcome, self.severity)
+
+
+def build_validation_report(validations: List[ValidationStrategy],
+                            connection: DuckDBPyConnection) -> list[ValidationOutcome]:
+    """
+    Builds a list of ValidationOutcomes from list of validation checks.
+    input:
+      validations: a list of ValidationStrategy objects
+      connection: a DuckDB connection object
+    returns: a list of ValidationOutcomes
+    """
+    validation_report = []
+    for v in validations:
+        validation_report.append(v.validate(connection))
+    return validation_report
+
+
+def build_spark_validation_report(validations: List[ValidationStrategy],
+                                  connection: DuckDBPyConnection,
+                                  spark: SparkSession) -> DataFrame:
+    """
+    Builds a Spark DataFrame containing the validation report.
+    input:
+      validations: a list of ValidationStrategy objects
+      connection: a DuckDB connection object
+    returns: a Spark DataFrame with the validation outcomes
+    """
+    report = build_validation_report(validations, connection)
+    data = list(map(lambda x: (x.table, x.column, x.strategy, x.outcome, x.severity), report))
+    schema = "table STRING, column STRING, strategy STRING, outcome STRING, severity STRING"
+    report_df = spark.createDataFrame(data, schema)
+    return report_df


### PR DESCRIPTION
## Changes

### What does this PR do?
Sometimes a profiler run will contain incomplete or corrupt outputs, leading to delays with the customer. This PR adds a classes for defining table validation checks and receiving validation outcomes as a list or Spark DataFrame outputs. These checks will be used to validate that a profiler run was successful and an accurate TCO estimate will be made prior to sending the information to the Databricks team.

### Relevant implementation details

### Caveats/things to watch out for when reviewing:

### Linked issues

N/A

### Functionality

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs lakebridge ...`
- [X] To be hooked into the profiler CLI when #1623 is merged.

### Tests

- [X] manually tested
- [X] added unit tests
- [ ] added integration tests
