### PR TITLE
Detect during install/upgrade if transpilers are installed and potentially need upgrade

### DIFF
--- a/src/databricks/labs/lakebridge/base_install.py
+++ b/src/databricks/labs/lakebridge/base_install.py
@@ -2,12 +2,17 @@ from databricks.labs.blueprint.logger import install_logger
 from databricks.labs.blueprint.entrypoint import get_logger
 from databricks.sdk.core import with_user_agent_extra
 
-install_logger()
-with_user_agent_extra("cmd", "install")
 
-if __name__ == "__main__":
+def main() -> None:
+    install_logger()
+    with_user_agent_extra("cmd", "install")
+
     logger = get_logger(__file__)
     logger.setLevel("INFO")
 
     logger.info("Successfully Setup Lakebridge Components Locally")
     logger.info("For more information, please visit https://databrickslabs.github.io/lakebridge/")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/databricks/labs/lakebridge/cli.py
+++ b/src/databricks/labs/lakebridge/cli.py
@@ -27,12 +27,11 @@ from databricks.labs.lakebridge.assessments.configure_assessment import (
     PROFILER_SOURCE_SYSTEM,
 )
 
-from databricks.labs.lakebridge.__about__ import __version__
 from databricks.labs.lakebridge.config import TranspileConfig
 from databricks.labs.lakebridge.contexts.application import ApplicationContext
 from databricks.labs.lakebridge.helpers.recon_config_utils import ReconConfigPrompts
 from databricks.labs.lakebridge.helpers.telemetry_utils import make_alphanum_or_semver
-from databricks.labs.lakebridge.install import WorkspaceInstaller
+from databricks.labs.lakebridge.install import WorkspaceInstaller, installer
 from databricks.labs.lakebridge.reconcile.runner import ReconcileRunner
 from databricks.labs.lakebridge.lineage import lineage_generator
 from databricks.labs.lakebridge.reconcile.recon_config import RECONCILE_OPERATION_NAME, AGG_RECONCILE_OPERATION_NAME
@@ -53,17 +52,7 @@ def raise_validation_exception(msg: str) -> NoReturn:
 
 
 def _installer(ws: WorkspaceClient, transpiler_repository: TranspilerRepository) -> WorkspaceInstaller:
-    app_context = ApplicationContext(_verify_workspace_client(ws))
-    return WorkspaceInstaller(
-        app_context.workspace_client,
-        app_context.prompts,
-        app_context.installation,
-        app_context.install_state,
-        app_context.product_info,
-        app_context.resource_configurator,
-        app_context.workspace_installation,
-        transpiler_repository=transpiler_repository,
-    )
+    return installer(ws, transpiler_repository)
 
 
 def _create_warehouse(ws: WorkspaceClient) -> str:
@@ -87,19 +76,6 @@ def _create_warehouse(ws: WorkspaceClient) -> str:
 def _remove_warehouse(ws: WorkspaceClient, warehouse_id: str):
     ws.warehouses.delete(warehouse_id)
     logger.info(f"Removed warehouse post installation with id: {warehouse_id}")
-
-
-def _verify_workspace_client(ws: WorkspaceClient) -> WorkspaceClient:
-    """
-    [Private] Verifies and updates the workspace client configuration.
-    """
-
-    # Using reflection to set right value for _product_info for telemetry
-    product_info = getattr(ws.config, '_product_info')
-    if product_info[0] != "lakebridge":
-        setattr(ws.config, '_product_info', ('lakebridge', __version__))
-
-    return ws
 
 
 @lakebridge.command
@@ -640,14 +616,14 @@ def install_transpile(
     artifact: str | None = None,
     transpiler_repository: TranspilerRepository = TranspilerRepository.user_home(),
 ) -> None:
-    """Install the Lakebridge transpilers"""
+    """Install or upgrade the Lakebridge transpilers."""
     with_user_agent_extra("cmd", "install-transpile")
     if artifact:
         with_user_agent_extra("artifact-overload", Path(artifact).name)
     user = w.current_user
     logger.debug(f"User: {user}")
-    installer = _installer(w, transpiler_repository)
-    installer.run(module="transpile", artifact=artifact)
+    transpile_installer = installer(w, transpiler_repository)
+    transpile_installer.run(module="transpile", artifact=artifact)
 
 
 @lakebridge.command(is_unauthenticated=False)
@@ -663,8 +639,8 @@ def configure_reconcile(
         dbsql_id = _create_warehouse(w)
         w.config.warehouse_id = dbsql_id
     logger.debug(f"Warehouse ID used for configuring reconcile: {w.config.warehouse_id}.")
-    installer = _installer(w, transpiler_repository)
-    installer.run(module="reconcile")
+    reconcile_installer = installer(w, transpiler_repository)
+    reconcile_installer.run(module="reconcile")
 
 
 @lakebridge.command()

--- a/src/databricks/labs/lakebridge/install.py
+++ b/src/databricks/labs/lakebridge/install.py
@@ -25,6 +25,7 @@ from databricks.labs.blueprint.wheels import ProductInfo
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.errors import NotFound, PermissionDenied
 
+from databricks.labs.lakebridge.__about__ import __version__
 from databricks.labs.lakebridge.config import (
     DatabaseConfig,
     ReconcileConfig,
@@ -32,6 +33,7 @@ from databricks.labs.lakebridge.config import (
     ReconcileMetadataConfig,
     TranspileConfig,
 )
+from databricks.labs.lakebridge.contexts.application import ApplicationContext
 from databricks.labs.lakebridge.deployment.configurator import ResourceConfigurator
 from databricks.labs.lakebridge.deployment.installation import WorkspaceInstallation
 from databricks.labs.lakebridge.reconcile.constants import ReconReportType, ReconSourceType
@@ -798,3 +800,28 @@ class WorkspaceInstaller:
 
     def _has_necessary_access(self, catalog_name: str, schema_name: str, volume_name: str | None = None):
         self._resource_configurator.has_necessary_access(catalog_name, schema_name, volume_name)
+
+
+def installer(ws: WorkspaceClient, transpiler_repository: TranspilerRepository) -> WorkspaceInstaller:
+    app_context = ApplicationContext(_verify_workspace_client(ws))
+    return WorkspaceInstaller(
+        app_context.workspace_client,
+        app_context.prompts,
+        app_context.installation,
+        app_context.install_state,
+        app_context.product_info,
+        app_context.resource_configurator,
+        app_context.workspace_installation,
+        transpiler_repository=transpiler_repository,
+    )
+
+
+def _verify_workspace_client(ws: WorkspaceClient) -> WorkspaceClient:
+    """Verifies the workspace client configuration, ensuring it has the correct product info."""
+
+    # Using reflection to set right value for _product_info for telemetry
+    product_info = getattr(ws.config, '_product_info')
+    if product_info[0] != "lakebridge":
+        setattr(ws.config, '_product_info', ('lakebridge', __version__))
+
+    return ws

--- a/src/databricks/labs/lakebridge/install.py
+++ b/src/databricks/labs/lakebridge/install.py
@@ -266,14 +266,14 @@ class WheelInstaller(TranspilerInstaller):
             raise ValueError("Installed transpiler is missing a 'config.yml' file in its 'lsp' folder")
         install_ext = "ps1" if sys.platform == "win32" else "sh"
         install_script = f"installer.{install_ext}"
-        installer = self._install_path / install_script
-        if installer.exists():
-            self._run_custom_installer(installer)
+        installer_path = self._install_path / install_script
+        if installer_path.exists():
+            self._run_custom_installer(installer_path)
         return self._install_path
 
-    def _run_custom_installer(self, installer):
-        args = [str(installer)]
-        run(args, stdin=sys.stdin, stdout=sys.stdout, stderr=sys.stderr, cwd=str(self._install_path), check=True)
+    def _run_custom_installer(self, installer_path: Path) -> None:
+        args = [installer_path]
+        run(args, stdin=sys.stdin, stdout=sys.stdout, stderr=sys.stderr, cwd=self._install_path, check=True)
 
 
 class MavenInstaller(TranspilerInstaller):


### PR DESCRIPTION
## Changes

This PR updates the install process for Lakebridge so that it detects if transpilers are already installed. If detected, the user is notified that they might need to be upgraded.

This is the first step to automatically upgrading the transpilers, which is easier once this PR is in place.

### Relevant implementation details

The Databricks CLI treats upgrading a component (like `lakebridge`) as an install: there's no separate hook in `labs.yml` for upgrades vs installs.

### Linked issues

Progresses #1836.

### Functionality

- modified existing commands:
   - `databricks labs install lakebridge`
   - `databricks labs upgrade lakebridge`

### Tests

- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
