### PR TITLE
Simplify Assessment CLI Prompts for Azure Synapse

### DIFF
--- a/src/databricks/labs/lakebridge/assessments/configure_assessment.py
+++ b/src/databricks/labs/lakebridge/assessments/configure_assessment.py
@@ -125,8 +125,6 @@ class ConfigureSynapseAssessment(AssessmentConfigurator):
         logger.info("Please provide Synapse Workspace settings:")
         synapse_workspace = {
             "name": self.prompts.question("Enter Synapse workspace name"),
-            "dedicated_sql_endpoint": self.prompts.question("Enter dedicated SQL endpoint"),
-            "serverless_sql_endpoint": self.prompts.question("Enter serverless SQL endpoint"),
             "sql_user": self.prompts.question("Enter SQL user"),
             "sql_password": self.prompts.question("Enter SQL password"),
             "tz_info": self.prompts.question("Enter timezone (e.g. America/New_York)", default="UTC"),
@@ -134,11 +132,13 @@ class ConfigureSynapseAssessment(AssessmentConfigurator):
                 "Enter the ODBC driver installed locally", default="ODBC Driver 18 for SQL Server"
             ),
         }
+        synapse_workspace["dedicated_sql_endpoint"] = f"{synapse_workspace['name']}.sql.azuresynapse.net"
+        synapse_workspace["serverless_sql_endpoint"] = f"{synapse_workspace['name']}-ondemand.sql.azuresynapse.net"
 
         # Azure API Access Settings
         logger.info("Please provide Azure API access settings:")
         azure_api_access = {
-            "development_endpoint": self.prompts.question("Enter development endpoint"),
+            "development_endpoint": f"https://{synapse_workspace['name']}.dev.azuresynapse.net",
             "azure_client_id": self.prompts.question("Enter Azure client ID"),
             "azure_tenant_id": self.prompts.question("Enter Azure tenant ID"),
             "azure_client_secret": self.prompts.question("Enter Azure client secret"),

--- a/tests/unit/assessment/test_assessment.py
+++ b/tests/unit/assessment/test_assessment.py
@@ -112,7 +112,6 @@ def test_configure_synapse_credentials(tmp_path):
 
     with open(file, 'r', encoding='utf-8') as file:
         credentials = yaml.safe_load(file)
-    print(credentials)
     assert credentials == expected_credentials
 
 

--- a/tests/unit/assessment/test_assessment.py
+++ b/tests/unit/assessment/test_assessment.py
@@ -50,13 +50,10 @@ def test_configure_synapse_credentials(tmp_path):
         {
             r"Enter secret vault type \(local \| env\)": sorted(['local', 'env']).index("env"),
             r"Enter Synapse workspace name": "test-workspace",
-            r"Enter dedicated SQL endpoint": "test-dedicated-endpoint",
-            r"Enter serverless SQL endpoint": "test-serverless-endpoint",
             r"Enter SQL user": "test-user",
             r"Enter SQL password": "test-password",
             r"Enter timezone \(e.g. America/New_York\)": "UTC",
             r"Enter the ODBC driver installed locally": "ODBC Driver 18 for SQL Server",
-            r"Enter development endpoint": "test-dev-endpoint",
             r"Enter Azure client ID": "test-client-id",
             r"Enter Azure tenant ID": "test-tenant-id",
             r"Enter Azure client secret": "test-client-secret",
@@ -85,15 +82,15 @@ def test_configure_synapse_credentials(tmp_path):
         'synapse': {
             'workspace': {
                 'name': 'test-workspace',
-                'dedicated_sql_endpoint': 'test-dedicated-endpoint',
-                'serverless_sql_endpoint': 'test-serverless-endpoint',
+                'dedicated_sql_endpoint': 'test-workspace.sql.azuresynapse.net',
+                'serverless_sql_endpoint': 'test-workspace-ondemand.sql.azuresynapse.net',
                 'sql_user': 'test-user',
                 'sql_password': 'test-password',
                 'tz_info': 'UTC',
                 'driver': 'ODBC Driver 18 for SQL Server',
             },
             'azure_api_access': {
-                'development_endpoint': 'test-dev-endpoint',
+                'development_endpoint': 'https://test-workspace.dev.azuresynapse.net',
                 'azure_client_id': 'test-client-id',
                 'azure_tenant_id': 'test-tenant-id',
                 'azure_client_secret': 'test-client-secret',
@@ -115,7 +112,7 @@ def test_configure_synapse_credentials(tmp_path):
 
     with open(file, 'r', encoding='utf-8') as file:
         credentials = yaml.safe_load(file)
-
+    print(credentials)
     assert credentials == expected_credentials
 
 


### PR DESCRIPTION
## Changes
Simplify the prompts for the Azure Synapse Assessment CLI.

### What does this PR do?

### Relevant implementation details
The serverless SQL endpoint, dedicated SQL endpoint, and development endpoint follow a predicatable and repeatable pattern based on the name of an Azure Synapse workspace name. The formats are as follows: 

- **Serverless SQL Endpoint:** _**<workspace_name>**_-ondemand.sql.azuresynapse.net
- **Dedicated SQL Endpoint:** **_<workspace_name>_**.sql.azuresynapse.net
- **Development Endpont:** https://**_<workspace_name>_**.dev.azuresynapse.net

Since these values can be automatically derived from the workspace name, the user only needs to be prompted to enter the name of the workspace they would like to profile. This PR removes the 3 redundant prompts.

### Caveats/things to watch out for when reviewing:

### Linked issues
N/A

### Functionality

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs lakebridge ...`
- [x] updated existing Assessment CLI

### Tests

- [ ] manually tested
- [X] updated existing unit tests
- [ ] added integration tests
