### PR TITLE
SQL Validator check for only sql outputs

### DIFF
--- a/src/databricks/labs/lakebridge/helpers/validation.py
+++ b/src/databricks/labs/lakebridge/helpers/validation.py
@@ -37,13 +37,15 @@ class Validator:
             config.catalog_name,
             config.schema_name,
         )
+        # Some errors doesn't return the query test alon with the error message so need to handle those separately
+        static_errors_lkp = ["[UNRESOLVED_ROUTINE]", "[UNRESOLVED_COLUMN.WITHOUT_SUGGESTION]"]
         if is_valid:
             result = sql_text
             if exception_type is not None:
                 exception_msg = f"[{exception_type.upper()}]: {exception_msg}"
         else:
             query = ""
-            if "[UNRESOLVED_ROUTINE]" in str(exception_msg):
+            if any(err in str(exception_msg) for err in static_errors_lkp):
                 query = sql_text
             buffer = StringIO()
             buffer.write("-------------- Exception Start-------------------\n")

--- a/src/databricks/labs/lakebridge/helpers/validation.py
+++ b/src/databricks/labs/lakebridge/helpers/validation.py
@@ -49,9 +49,9 @@ class Validator:
                 query = sql_text
             buffer = StringIO()
             buffer.write("-------------- Exception Start-------------------\n")
-            buffer.write("/* \n")
+            buffer.write("/*\n")
             buffer.write(str(exception_msg))
-            buffer.write("\n */ \n")
+            buffer.write("\n*/\n")
             buffer.write(query)
             buffer.write("\n ---------------Exception End --------------------\n")
 

--- a/src/databricks/labs/lakebridge/transpiler/execute.py
+++ b/src/databricks/labs/lakebridge/transpiler/execute.py
@@ -48,6 +48,26 @@ class TranspilingContext:
     transpiled_code: str | None = None
 
 
+def _validate_transpiled_sql(context: TranspilingContext, content: str, error_list: list[TranspileError]) -> str:
+    if context.validator is None:
+        return content
+    validation_result = _validation(context.validator, context.config, str(content))
+    # Potentially expensive, only evaluate if debug is enabled
+    if logger.isEnabledFor(logging.DEBUG):
+        msg = f"Finished validating transpiled code for file: {context.input_path} (result: {validation_result})"
+        logger.debug(msg)
+    if validation_result.exception_msg is not None:
+        error = TranspileError(
+            "VALIDATION_ERROR",
+            ErrorKind.VALIDATION,
+            ErrorSeverity.WARNING,
+            context.input_path,
+            validation_result.exception_msg,
+        )
+        error_list.append(error)
+    return validation_result.validated_sql
+
+
 async def _process_one_file(context: TranspilingContext) -> tuple[int, list[TranspileError]]:
     input_path = context.input_path
 
@@ -89,29 +109,29 @@ async def _process_one_file(context: TranspilingContext) -> tuple[int, list[Tran
     assert output_path is not None, "Output path must be set in the context"
     output_path.parent.mkdir(exist_ok=True)
 
-    if _is_combined_result(transpile_result):
-        _process_combined_result(context, error_list)
+    if _is_mime_result(transpile_result):
+        _process_mime_result(context, error_list)
     else:
-        _process_single_result(context, error_list)
+        _process_non_mime_result(context, error_list)
 
     return transpile_result.success_count, error_list
 
 
-def _is_combined_result(result: TranspileResult):
+def _is_mime_result(result: TranspileResult):
     return result.transpiled_code.startswith("Content-Type: multipart/mixed; boundary=")
 
 
-def _process_combined_result(context: TranspilingContext, _error_list: list[TranspileError]) -> None:
+def _process_mime_result(context: TranspilingContext, error_list: list[TranspileError]) -> None:
     # TODO error handling
     # Added policy to process quoted-printable encoded
     parser = EmailParser(policy=policy.default)
     transpiled_code: str = cast(str, context.transpiled_code)
     message: Message = parser.parsestr(transpiled_code)
     for part in message.walk():
-        _process_combined_part(context, part)
+        _process_combined_part(context, part, error_list)
 
 
-def _process_combined_part(context: TranspilingContext, part: Message) -> None:
+def _process_combined_part(context: TranspilingContext, part: Message, error_list: list[TranspileError]) -> None:
     if part.get_content_type() != "text/plain":
         return  # TODO Need to handle other content types, e.g., text/binary, application/json, etc.
     filename = part.get_filename()
@@ -133,35 +153,21 @@ def _process_combined_part(context: TranspilingContext, part: Message) -> None:
         folder.mkdir(parents=True, exist_ok=True)
     output = folder / segments[-1]
     logger.debug(f"Writing output to: {output}")
+    # Only validate if output file has .sql suffix
+    if context.validator and output.suffix == ".sql":
+        content = _validate_transpiled_sql(context, content, error_list)
     output.write_text(content)
 
 
-def _process_single_result(context: TranspilingContext, error_list: list[TranspileError]) -> None:
+def _process_non_mime_result(context: TranspilingContext, error_list: list[TranspileError]) -> None:
 
     output_code: str = context.transpiled_code or ""
+    output_path = cast(Path, context.output_path)
 
     if any(err.kind == ErrorKind.PARSING for err in error_list):
         output_code = context.source_code or ""
-
-    elif context.validator:
-        logger.debug(f"Validating transpiled code for file: {context.input_path}")
-        validation_result = _validation(context.validator, context.config, str(context.transpiled_code))
-        # Potentially expensive, only evaluate if debug is enabled
-        if logger.isEnabledFor(logging.DEBUG):
-            msg = f"Finished validating transpiled code for file: {context.input_path} (result: {validation_result})"
-            logger.debug(msg)
-        if validation_result.exception_msg is not None:
-            error = TranspileError(
-                "VALIDATION_ERROR",
-                ErrorKind.VALIDATION,
-                ErrorSeverity.WARNING,
-                context.input_path,
-                validation_result.exception_msg,
-            )
-            error_list.append(error)
-        output_code = validation_result.validated_sql
-
-    output_path = cast(Path, context.output_path)
+    elif context.validator and output_path.suffix == ".sql":
+        output_code = _validate_transpiled_sql(context, output_code, error_list)
     with output_path.open("w") as w:
         # The above adds a java-style comment block at the top of the output file
         # This would break .py or .json outputs so we disable it for now.

--- a/src/databricks/labs/lakebridge/transpiler/execute.py
+++ b/src/databricks/labs/lakebridge/transpiler/execute.py
@@ -154,7 +154,7 @@ def _process_combined_part(context: TranspilingContext, part: Message, error_lis
     output = folder / segments[-1]
     logger.debug(f"Writing output to: {output}")
     # Only validate if output file has .sql suffix
-    if context.validator and output.suffix == ".sql":
+    if output.suffix == ".sql":
         content = _validate_transpiled_sql(context, content, error_list)
     output.write_text(content)
 
@@ -166,7 +166,7 @@ def _process_non_mime_result(context: TranspilingContext, error_list: list[Trans
 
     if any(err.kind == ErrorKind.PARSING for err in error_list):
         output_code = context.source_code or ""
-    elif context.validator and output_path.suffix == ".sql":
+    elif output_path.suffix == ".sql":
         output_code = _validate_transpiled_sql(context, output_code, error_list)
     with output_path.open("w") as w:
         # The above adds a java-style comment block at the top of the output file

--- a/tests/integration/transpile/common_utils.py
+++ b/tests/integration/transpile/common_utils.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+from databricks.labs.lakebridge.config import TranspileConfig
+from databricks.labs.lakebridge.transpiler.execute import transpile
+
+
+def assert_sql_outputs(output_folder: Path, expected_sql: str, expected_failure_sql: str) -> None:
+    assert (output_folder / "create_ddl.sql").exists()
+    with open(output_folder / "create_ddl.sql", "r", encoding="utf-8") as f:
+        actual_sql = f.read()
+    assert actual_sql.strip() == expected_sql.strip()
+
+    assert (output_folder / "dummy_function.sql").exists()
+    with open(output_folder / "dummy_function.sql", "r", encoding="utf-8") as f:
+        actual_failure_sql = f.read()
+    assert actual_failure_sql.strip() == expected_failure_sql.strip()
+
+
+async def run_transpile_and_assert(
+    ws,
+    lsp_engine,
+    config_path,
+    input_source,
+    output_folder,
+    source_dialect,
+    expected_sql,
+    expected_failure_sql,
+):
+
+    transpile_config = TranspileConfig(
+        transpiler_config_path=str(config_path),
+        source_dialect=source_dialect,
+        input_source=str(input_source),
+        output_folder=str(output_folder),
+        skip_validation=False,
+        catalog_name="catalog",
+        schema_name="schema",
+    )
+    await transpile(ws, lsp_engine, transpile_config)
+    assert_sql_outputs(output_folder, expected_sql, expected_failure_sql)

--- a/tests/integration/transpile/test_bladebridge.py
+++ b/tests/integration/transpile/test_bladebridge.py
@@ -9,8 +9,15 @@ from databricks.labs.lakebridge.install import WheelInstaller
 from databricks.labs.lakebridge.transpiler.execute import transpile
 from databricks.labs.lakebridge.transpiler.lsp.lsp_engine import LSPEngine
 from databricks.labs.lakebridge.transpiler.repository import TranspilerRepository
+from .common_utils import run_transpile_and_assert
 
 logger = logging.getLogger(__name__)
+
+
+def _install_bladebridge(transpiler_repository: TranspilerRepository, bladebridge_artifact: Path | None) -> tuple:
+    WheelInstaller(transpiler_repository, "bladebridge", "databricks-bb-plugin", bladebridge_artifact).install()
+    config_path = transpiler_repository.transpiler_config_path("Bladebridge")
+    return config_path, LSPEngine.from_config_path(config_path)
 
 
 async def test_transpiles_informatica_with_sparksql(
@@ -30,9 +37,8 @@ async def _transpile_informatica_with_sparksql(
     bladebridge_artifact: Path,
     output_folder: Path,
 ) -> None:
-    WheelInstaller(transpiler_repository, "bladebridge", "databricks-bb-plugin", bladebridge_artifact).install()
-    config_path = transpiler_repository.transpiler_config_path("Bladebridge")
-    lsp_engine = LSPEngine.from_config_path(config_path)
+
+    config_path, lsp_engine = _install_bladebridge(transpiler_repository, bladebridge_artifact)
     input_source = Path(__file__).parent.parent.parent / "resources" / "functional" / "informatica"
     transpile_config = TranspileConfig(
         transpiler_config_path=str(config_path),
@@ -52,3 +58,63 @@ async def _transpile_informatica_with_sparksql(
     assert (output_folder / "m_employees_load.py").exists()
     assert (output_folder / "wf_m_employees_load.json").exists()
     assert (output_folder / "wf_m_employees_load_params.py").exists()
+
+
+async def test_transpile_sql_file(ws: WorkspaceClient, tmp_path: Path) -> None:
+    labs_path = tmp_path / "labs"
+    output_folder = tmp_path / "output"
+    transpiler_repository = TranspilerRepository(labs_path)
+    await _transpile_bb_sql_file(ws, transpiler_repository, output_folder)
+
+
+async def _transpile_bb_sql_file(
+    ws: WorkspaceClient,
+    transpiler_repository: TranspilerRepository,
+    bb_output_folder: Path,
+) -> None:
+    # SQL Version installs latest Bladebridge from pypi
+    config_path, lsp_engine = _install_bladebridge(transpiler_repository, None)
+    bb_input_source = Path(__file__).parent.parent.parent / "resources" / "functional" / "teradata" / "integration"
+    # The expected SQL Block is custom formatted to match the output of Bladebridge exactly.
+    expected_teradata_sql = """CREATE TABLE REF_TABLE
+(
+    col1    TINYINT NOT NULL,
+    col2    SMALLINT NOT NULL,
+    col3    INTEGER NOT NULL,
+    col4    BIGINT NOT NULL,
+    col5    DECIMAL(10,2) NOT NULL,
+    col6    DECIMAL(18,4) NOT NULL,
+    col7    TIMESTAMP NOT NULL,
+    col8    TIMESTAMP,
+    col9    TIMESTAMP NOT NULL,
+    col10   STRING NOT NULL,
+    col11   STRING NOT NULL,
+    col12   STRING,
+    col13   DECIMAL(10,0) NOT NULL,
+    col14   DECIMAL(18,6) NOT NULL,
+    col15   DECIMAL(18,1) NOT NULL DEFAULT 0.0,
+    col16   DATE,
+    col17 STRING COLLATE UTF8_LCASE,
+    col18   FLOAT NOT NULL,
+PRIMARY KEY (col1,col3) )
+TBLPROPERTIES('delta.feature.allowColumnDefaults' = 'supported');"""
+    # The expected SQL Block is custom formatted to match the output of Bladebridge exactly.
+    # TODO Validate why Morpheus and Bladebridge provides different output for same input, Bladebridge seems to be more correct on validation focused errors.
+    expected_validation_failure_sql = """-------------- Exception Start-------------------
+/*
+[UNRESOLVED_ROUTINE] Cannot resolve routine `cole` on search path [`system`.`builtin`, `system`.`session`, `catalog`.`schema`].
+*/
+select cole(hello) world from table;
+
+ ---------------Exception End --------------------"""
+
+    await run_transpile_and_assert(
+        ws,
+        lsp_engine,
+        config_path,
+        bb_input_source,
+        bb_output_folder,
+        "teradata",
+        expected_teradata_sql,
+        expected_validation_failure_sql,
+    )

--- a/tests/integration/transpile/test_morpheus.py
+++ b/tests/integration/transpile/test_morpheus.py
@@ -77,16 +77,17 @@ async def _transpile_sql_file(
     expected_failure_sql = """-------------- Exception Start-------------------
 /*
 
-[PARSE_SYNTAX_ERROR] Syntax error at or near '.'. SQLSTATE: 42601 (line 2, "
-pos 7)
+[PARSE_SYNTAX_ERROR] Syntax error at or near '.'. SQLSTATE: 42601 (line 2, pos 7)
+
 == SQL ==
 EXPLAIN SELECT
   cole(...) AS world
 -------^^^
 FROM
- table;
+  table;
 
  */
+
  ---------------Exception End --------------------"""
 
     transpile_config = TranspileConfig(

--- a/tests/integration/transpile/test_morpheus.py
+++ b/tests/integration/transpile/test_morpheus.py
@@ -86,7 +86,7 @@ EXPLAIN SELECT
 FROM
   table;
 
- */
+*/
 
  ---------------Exception End --------------------"""
 

--- a/tests/integration/transpile/test_morpheus.py
+++ b/tests/integration/transpile/test_morpheus.py
@@ -7,6 +7,7 @@ from databricks.labs.lakebridge.install import MavenInstaller
 from databricks.labs.lakebridge.transpiler.execute import transpile
 from databricks.labs.lakebridge.transpiler.lsp.lsp_engine import LSPEngine
 from databricks.labs.lakebridge.transpiler.repository import TranspilerRepository
+from .common_utils import run_transpile_and_assert
 
 
 def _install_morpheus(transpiler_repository: TranspilerRepository) -> tuple:
@@ -73,7 +74,8 @@ async def _transpile_sql_file(
   department_id DECIMAL(38, 0),
   remarks VARIANT
 );"""
-
+    # TODO investigate why morpheus produces a different error to baldebridge for the same query
+    # The expected SQL Block is custom formatted to match the output of Morpheus exactly.
     expected_failure_sql = """-------------- Exception Start-------------------
 /*
 
@@ -90,23 +92,14 @@ FROM
 
  ---------------Exception End --------------------"""
 
-    transpile_config = TranspileConfig(
-        transpiler_config_path=str(config_path),
-        source_dialect="snowflake",
-        input_source=str(input_source),
-        output_folder=str(output_folder),
-        skip_validation=False,
-        catalog_name="catalog",
-        schema_name="schema",
-    )
     # TODO: Load the engine here, via the validation path.
-    await transpile(ws, lsp_engine, transpile_config)
-    assert (output_folder / "create_ddl.sql").exists()
-    with open(output_folder / "create_ddl.sql", "r", encoding="utf-8") as f:
-        actual_sql = f.read()
-    assert actual_sql.strip() == expected_sql.strip()
-
-    assert (output_folder / "dummy_function.sql").exists()
-    with open(output_folder / "dummy_function.sql", "r", encoding="utf-8") as f:
-        actual_failure_sql = f.read()
-    assert actual_failure_sql.strip() == expected_failure_sql.strip()
+    await run_transpile_and_assert(
+        ws,
+        lsp_engine,
+        config_path,
+        input_source,
+        output_folder,
+        "snowflake",
+        expected_sql,
+        expected_failure_sql,
+    )

--- a/tests/integration/transpile/test_morpheus.py
+++ b/tests/integration/transpile/test_morpheus.py
@@ -9,6 +9,12 @@ from databricks.labs.lakebridge.transpiler.lsp.lsp_engine import LSPEngine
 from databricks.labs.lakebridge.transpiler.repository import TranspilerRepository
 
 
+def _install_morpheus(transpiler_repository: TranspilerRepository) -> tuple:
+    MavenInstaller(transpiler_repository, "morpheus", "com.databricks.labs", "databricks-morph-plugin").install()
+    config_path = transpiler_repository.transpiler_config_path("Morpheus")
+    return config_path, LSPEngine.from_config_path(config_path)
+
+
 async def test_transpiles_all_dbt_project_files(ws: WorkspaceClient, tmp_path: Path) -> None:
     labs_path = tmp_path / "labs"
     output_folder = tmp_path / "output"
@@ -21,10 +27,67 @@ async def _transpile_all_dbt_project_files(
     transpiler_repository: TranspilerRepository,
     output_folder: Path,
 ) -> None:
-    MavenInstaller(transpiler_repository, "morpheus", "com.databricks.labs", "databricks-morph-plugin").install()
-    config_path = transpiler_repository.transpiler_config_path("Morpheus")
-    lsp_engine = LSPEngine.from_config_path(config_path)
+    config_path, lsp_engine = _install_morpheus(transpiler_repository)
     input_source = Path(__file__).parent.parent.parent / "resources" / "functional" / "dbt"
+
+    transpile_config = TranspileConfig(
+        transpiler_config_path=str(config_path),
+        source_dialect="snowflake",
+        input_source=str(input_source),
+        output_folder=str(output_folder),
+        skip_validation=True,
+        catalog_name="catalog",
+        schema_name="schema",
+    )
+    # TODO: Load the engine here, via the validation path.
+    await transpile(ws, lsp_engine, transpile_config)
+    assert (output_folder / "top-query.sql").exists()
+    assert (output_folder / "dbt_project.yml").exists()
+    assert (output_folder / "sub" / "sub-query.sql").exists()
+    assert (output_folder / "sub" / "sub-query-bom.sql").exists()
+    assert (output_folder / "sub" / "dbt_project.yml").exists()
+
+
+async def test_transpile_sql_file(ws: WorkspaceClient, tmp_path: Path) -> None:
+    labs_path = tmp_path / "labs"
+    output_folder = tmp_path / "output"
+    transpiler_repository = TranspilerRepository(labs_path)
+    await _transpile_sql_file(ws, transpiler_repository, output_folder)
+
+
+async def _transpile_sql_file(
+    ws: WorkspaceClient,
+    transpiler_repository: TranspilerRepository,
+    output_folder: Path,
+) -> None:
+    config_path, lsp_engine = _install_morpheus(transpiler_repository)
+    input_source = Path(__file__).parent.parent.parent / "resources" / "functional" / "snowflake" / "integration"
+    # The expected SQL Block is custom formatted to match the output of Morpheus exactly.
+    expected_sql = """CREATE TABLE employee (
+  employee_id DECIMAL(38, 0),
+  first_name VARCHAR(50) NOT NULL,
+  last_name VARCHAR(50) NOT NULL,
+  birth_date DATE,
+  hire_date DATE,
+  salary DECIMAL(10, 2),
+  department_id DECIMAL(38, 0),
+  remarks VARIANT
+);"""
+
+    expected_failure_sql = """-------------- Exception Start-------------------
+/*
+
+[PARSE_SYNTAX_ERROR] Syntax error at or near '.'. SQLSTATE: 42601 (line 2, "
+pos 7)
+== SQL ==
+EXPLAIN SELECT
+  cole(...) AS world
+-------^^^
+FROM
+ table;
+
+ */
+ ---------------Exception End --------------------"""
 
     transpile_config = TranspileConfig(
         transpiler_config_path=str(config_path),
@@ -37,8 +100,12 @@ async def _transpile_all_dbt_project_files(
     )
     # TODO: Load the engine here, via the validation path.
     await transpile(ws, lsp_engine, transpile_config)
-    assert (output_folder / "top-query.sql").exists()
-    assert (output_folder / "dbt_project.yml").exists()
-    assert (output_folder / "sub" / "sub-query.sql").exists()
-    assert (output_folder / "sub" / "sub-query-bom.sql").exists()
-    assert (output_folder / "sub" / "dbt_project.yml").exists()
+    assert (output_folder / "create_ddl.sql").exists()
+    with open(output_folder / "create_ddl.sql", "r", encoding="utf-8") as f:
+        actual_sql = f.read()
+    assert actual_sql.strip() == expected_sql.strip()
+
+    assert (output_folder / "dummy_function.sql").exists()
+    with open(output_folder / "dummy_function.sql", "r", encoding="utf-8") as f:
+        actual_failure_sql = f.read()
+    assert actual_failure_sql.strip() == expected_failure_sql.strip()

--- a/tests/resources/functional/snowflake/integration/create_ddl.sql
+++ b/tests/resources/functional/snowflake/integration/create_ddl.sql
@@ -1,0 +1,9 @@
+CREATE TABLE employee (employee_id INT,
+  first_name VARCHAR(50) NOT NULL,
+  last_name VARCHAR(50) NOT NULL,
+  birth_date DATE,
+  hire_date DATE,
+  salary DECIMAL(10, 2),
+  department_id INT,
+  remarks VARIANT)
+;

--- a/tests/resources/functional/snowflake/integration/dummy_function.sql
+++ b/tests/resources/functional/snowflake/integration/dummy_function.sql
@@ -1,0 +1,1 @@
+select cole(hello) world from table;

--- a/tests/resources/functional/teradata/integration/create_ddl.sql
+++ b/tests/resources/functional/teradata/integration/create_ddl.sql
@@ -1,0 +1,23 @@
+CREATE TABLE REF_TABLE
+    ,NO FALLBACK
+(
+    col1    BYTEINT NOT NULL,
+    col2    SMALLINT NOT NULL,
+    col3    INTEGER NOT NULL,
+    col4    BIGINT NOT NULL,
+    col5    DECIMAL(10,2) NOT NULL,
+    col6    DECIMAL(18,4) NOT NULL,
+    col7    TIMESTAMP(1) NOT NULL,
+    col8    TIME,
+    col9    TIMESTAMP(5) WITH TIME ZONE NOT NULL,
+    col10   CHAR(01) NOT NULL,
+    col11   CHAR(04) NOT NULL,
+    col12   CHAR(4),
+    col13   DECIMAL(10,0) NOT NULL,
+    col14   DECIMAL(18,6) NOT NULL,
+    col15   DECIMAL(18,1) NOT NULL DEFAULT 0.0,
+    col16   DATE FORMAT 'YY/MM/DD',
+    col17   VARCHAR(30) NOT CASESPECIFIC,
+    col18   FLOAT NOT NULL
+    )
+    UNIQUE PRIMARY INDEX (col1, col3);

--- a/tests/resources/functional/teradata/integration/dummy_function.sql
+++ b/tests/resources/functional/teradata/integration/dummy_function.sql
@@ -1,0 +1,1 @@
+select cole(hello) world from table;


### PR DESCRIPTION
<!-- REMOVE IRRELEVANT COMMENTS BEFORE CREATING A PULL REQUEST -->
## Changes
<!-- Summary of your changes that are easy to understand. Add screenshots when necessary, they're helpful to illustrate the before and after state -->
### What does this PR do?
- Enhanced support for MIME and non-MIME transpile results, including validation and output file management.
- Improved Validation error handling

### Relevant implementation details

- Additional Integration tests for the new validator functionality have been introduced.
- Validation report comments have been streamlined in the output `validation.py`.

### Caveats/things to watch out for when reviewing:

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #..

### Functionality

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs lakebridge ...`
- [ ] ... +add your own

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [ ] added unit tests
- [X] added integration tests
