### PR TITLE
Updated docs to remove reference to RCT

### DIFF
--- a/docs/lakebridge/docs/sql_splitter.mdx
+++ b/docs/lakebridge/docs/sql_splitter.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 9
 title: SQL Splitter
 ---
 import useBaseUrl from '@docusaurus/useBaseUrl';
@@ -21,9 +21,9 @@ This tool is particularly useful in situations where your SQL code is stored (or
 
 You might need the SQL Splitter when:
 
-- **Large SQL files contain multiple objects**:  
+- **Large SQL files contain multiple objects**:
   Example — one script has the definitions for tables, views, stored procedures, functions, and sequences all together.
-- **Working with Oracle packages**:  
+- **Working with Oracle packages**:
   The tool can split a package body/specification into **individual functions and procedures**, still grouped logically in output subfolders.
 
 ---
@@ -107,7 +107,7 @@ sql_splitter
     [-v]                        verbose mode
 ```
 
-**Note:**  
+**Note:**
 The output folder specified with `-o` **must already exist** before running the command. The SQL Splitter will create subfolders for each object type inside this folder.
 
 ---
@@ -126,8 +126,8 @@ This command:
 
 You can download the latest version of the **SQL Splitter** here:
 
-**Version:** 1.3.2  
-**Build Date:** 2025-01-31  
+**Version:** 1.3.2
+**Build Date:** 2025-01-31
 
 <a href={useBaseUrl('downloads/SQLSplitter.zip')} download>
   ⬇ Download SQLSplitter.zip

--- a/docs/lakebridge/docs/transpile/pluggable_transpilers/index.mdx
+++ b/docs/lakebridge/docs/transpile/pluggable_transpilers/index.mdx
@@ -8,24 +8,24 @@ Lakebridge _pluggable_ transpilers
 
 `Lakebridge` transpiles source code using _pluggable_ transpilers.
 They are pluggable in the sense that:
- - their code sits outside of the `lakebridge` code base
- - there can be more than 1 installed, although as of writing, `lakebridge` can only use 1 at a given point in time
- - `lakebridge` knows nothing about them until they are discovered at runtime
+ - their code sits outside of the `Lakebridge` code base
+ - there can be more than 1 installed, although as of writing, `Lakebridge` can only use 1 at a given point in time
+ - `Lakebridge` knows nothing about them until they are discovered at runtime
 
-Communication between `lakebridge` and a transpiler is achieved using `LSP`, see for example [this starter](https://github.com/databrickslabs/lakebridge-plugin-starters/tree/python-sdk/python) to learn more about how this works.
+Communication between `Lakebridge` and a transpiler is achieved using `LSP` - Language Server Protocol.
 
-This document describes how `lakebridge` discovers and runs transpilers.
+This document describes how `Lakebridge` discovers and runs transpilers.
 
-Although one could _in theory_ run a transpiler without access to the Databricks platform, `lakebridge` requires a valid Databricks install.
+Although one could _in theory_ run a transpiler without access to the Databricks platform, `Lakebridge` requires a valid Databricks install.
 Lakebridge leverages this by expecting transpilers to reside in the `.databricks` folder hierarchy, as follows:
 
 
 ```
 .databricks/
 ├── labs/
-│   ├── lakebridge-transpilers/
-│   │   ├── morpheus/
-│   │   ├── lakebridge-community-transpiler/
+│   ├── remorph-transpilers/
+│   │   ├── bladebridge/
+│   │   ├── databricks-morph-plugin/
 │   │   ├── some-3rd-party-transpiler/
 ```
 
@@ -64,16 +64,16 @@ custom: # this section is optional, it is passed to the transpiler at startup
     <key 1>: <value 1> # can be pretty much anything
 ```
 
-Databricks provides 2 transpilers: _Morpheus_, its advanced transpiler, and _RCT_ (Lakebridge Community Transpiler).
-These transpilers are installed by `lakebridge` itself as part of running the `install-transpile` command, as follows:
- - the latest _Morpheus_ is fetched from [Maven Central](https://central.sonatype.com/), and installed at `.databricks/labs/lakebridge-transpilers/morpheus/`.
- - the latest _RCT_ is fetched from [PyPi](https://pypi.org/), and installed at `.databricks/labs/lakebridge-transpilers/lakebridge-community-transpiler/`.
+Databricks provides 2 transpilers: _Morpheus_, its AST-based transpiler, and _BladeBridge_, a pattern-based transpiler.
+These transpilers are installed by `Lakebridge` itself as part of running the `install-transpile` command, as follows:
+ - the latest _Morpheus_ is fetched from [Maven Central](https://central.sonatype.com/), and installed at `.databricks/labs/remorph-transpilers/databricks-morph-plugin/`.
+ - the latest _BladeBridge_ is fetched from [PyPi](https://pypi.org/), and installed at `.databricks/labs/remorph-transpilers/bladebridge/`.
 
 Installing 3rd party transpilers is the responsibility of their provider.
 
-When `lakebridge` is configured, it scans the `lakebridge-transpilers` directory, and collects available source dialects and corresponding transpilers, such that the user can configure them as wished.
+When `Lakebridge` is configured, it scans the `lakebridge-transpilers` directory, and collects available source dialects and corresponding transpilers, such that the user can configure them as wished.
 
-When a user runs the _transpile_ command, `lakebridge` sets the working directory to the configured transpiler, appends the configured environment variables, and runs the configured command line.
+When a user runs the _transpile_ command, `Lakebridge` sets the working directory to the configured transpiler, appends the configured environment variables, and runs the configured command line.
 
 The transpiler is an LSP Server i.e. it listens to commands from _lakebridge_ until it is instructed to exit.
 
@@ -83,7 +83,7 @@ Manually installing a transpiler
 
 There are situations where an installer may fail: security rules preventing downloads, pre-releases...
 Following the above steps, it is straightforward to manually install a transpiler, by:
- - creating the transpiler folder in the `.databricks/labs/lakebridge-transpilers/` directory
+ - creating the transpiler folder in the `.databricks/labs/remorph-transpilers/` directory
  - creating the `lib` and `state` sub-folders
  - creating a `config.yml` file in the `lib` folder (see details above)
  - creating a `version.json` file in the `state` folder with content like:


### PR DESCRIPTION
### What does this PR do?
- Removes references to RCT
- Moves SQL Splitter page to the main menu