### PR TITLE
CLI entry points, enforce keyword arguments

### DIFF
--- a/src/databricks/labs/lakebridge/cli.py
+++ b/src/databricks/labs/lakebridge/cli.py
@@ -74,6 +74,7 @@ def _remove_warehouse(ws: WorkspaceClient, warehouse_id: str):
 
 @lakebridge.command
 def transpile(
+    *,
     w: WorkspaceClient,
     transpiler_config_path: str | None = None,
     source_dialect: str | None = None,
@@ -518,7 +519,7 @@ def _override_workspace_client_config(ctx: ApplicationContext, overrides: dict[s
 
 
 @lakebridge.command
-def reconcile(w: WorkspaceClient) -> None:
+def reconcile(*, w: WorkspaceClient) -> None:
     """[EXPERIMENTAL] Reconciles source to Databricks datasets"""
     with_user_agent_extra("cmd", "execute-reconcile")
     ctx = ApplicationContext(w)
@@ -534,7 +535,7 @@ def reconcile(w: WorkspaceClient) -> None:
 
 
 @lakebridge.command
-def aggregates_reconcile(w: WorkspaceClient) -> None:
+def aggregates_reconcile(*, w: WorkspaceClient) -> None:
     """[EXPERIMENTAL] Reconciles Aggregated source to Databricks datasets"""
     with_user_agent_extra("cmd", "execute-aggregates-reconcile")
     ctx = ApplicationContext(w)
@@ -552,8 +553,8 @@ def aggregates_reconcile(w: WorkspaceClient) -> None:
 
 @lakebridge.command
 def generate_lineage(
-    w: WorkspaceClient,
     *,
+    w: WorkspaceClient,
     source_dialect: str | None = None,
     input_source: str,
     output_folder: str,
@@ -578,7 +579,7 @@ def generate_lineage(
 
 
 @lakebridge.command
-def configure_secrets(w: WorkspaceClient) -> None:
+def configure_secrets(*, w: WorkspaceClient) -> None:
     """Setup reconciliation connection profile details as Secrets on Databricks Workspace"""
     recon_conf = ReconConfigPrompts(w)
 
@@ -604,8 +605,9 @@ def configure_database_profiler() -> None:
     assessment.run()
 
 
-@lakebridge.command()
+@lakebridge.command
 def install_transpile(
+    *,
     w: WorkspaceClient,
     artifact: str | None = None,
     transpiler_repository: TranspilerRepository = TranspilerRepository.user_home(),
@@ -622,6 +624,7 @@ def install_transpile(
 
 @lakebridge.command(is_unauthenticated=False)
 def configure_reconcile(
+    *,
     w: WorkspaceClient,
     transpiler_repository: TranspilerRepository = TranspilerRepository.user_home(),
 ) -> None:
@@ -637,8 +640,9 @@ def configure_reconcile(
     reconcile_installer.run(module="reconcile")
 
 
-@lakebridge.command()
+@lakebridge.command
 def analyze(
+    *,
     w: WorkspaceClient,
     source_directory: str | None = None,
     report_file: str | None = None,

--- a/tests/unit/test_cli_analyze.py
+++ b/tests/unit/test_cli_analyze.py
@@ -13,7 +13,9 @@ from databricks.labs.bladespector.analyzer import Analyzer
 
 def test_analyze_arguments(mock_workspace_client, tmp_path: Path):
     input_path = str(Path(__file__).parent.parent / "resources" / "functional" / "informatica")
-    cli.analyze(mock_workspace_client, input_path, "/tmp/sample", "Informatica - PC")
+    cli.analyze(
+        w=mock_workspace_client, source_directory=input_path, report_file="/tmp/sample", source_tech="Informatica - PC"
+    )
 
 
 def test_analyze_arguments_wrong_tech(mock_workspace_client, tmp_path: Path):
@@ -29,7 +31,12 @@ def test_analyze_arguments_wrong_tech(mock_workspace_client, tmp_path: Path):
 
     with patch.object(ApplicationContext, "prompts", mock_prompts):
         input_path = str(Path(__file__).parent.parent / "resources" / "functional" / "informatica")
-        cli.analyze(mock_workspace_client, input_path, "/tmp/sample.xlsx", "Informatica")
+        cli.analyze(
+            w=mock_workspace_client,
+            source_directory=input_path,
+            report_file="/tmp/sample.xlsx",
+            source_tech="Informatica",
+        )
 
 
 def test_analyze_prompts(mock_workspace_client, tmp_path: Path):
@@ -48,4 +55,4 @@ def test_analyze_prompts(mock_workspace_client, tmp_path: Path):
         }
     )
     with patch.object(ApplicationContext, "prompts", mock_prompts):
-        cli.analyze(mock_workspace_client)
+        cli.analyze(w=mock_workspace_client)

--- a/tests/unit/test_cli_lineage.py
+++ b/tests/unit/test_cli_lineage.py
@@ -30,7 +30,7 @@ def test_generate_lineage_valid_input(
 ) -> None:
     input_dir, output_dir = temp_dirs_for_lineage
     cli.generate_lineage(
-        mock_workspace_client,
+        w=mock_workspace_client,
         source_dialect="snowflake",
         input_source=str(input_dir),
         output_folder=str(output_dir),

--- a/tests/unit/test_cli_other.py
+++ b/tests/unit/test_cli_other.py
@@ -23,18 +23,18 @@ def test_configure_secrets_databricks(mock_workspace_client):
 
 def test_cli_configure_secrets_config(mock_workspace_client):
     with patch("databricks.labs.lakebridge.cli.ReconConfigPrompts") as mock_recon_config:
-        cli.configure_secrets(mock_workspace_client)
+        cli.configure_secrets(w=mock_workspace_client)
         mock_recon_config.assert_called_once_with(mock_workspace_client)
 
 
 def test_cli_reconcile(mock_workspace_client):
     with patch("databricks.labs.lakebridge.reconcile.runner.ReconcileRunner.run", return_value=True):
-        cli.reconcile(mock_workspace_client)
+        cli.reconcile(w=mock_workspace_client)
 
 
 def test_cli_aggregates_reconcile(mock_workspace_client):
     with patch("databricks.labs.lakebridge.reconcile.runner.ReconcileRunner.run", return_value=True):
-        cli.aggregates_reconcile(mock_workspace_client)
+        cli.aggregates_reconcile(w=mock_workspace_client)
 
 
 def test_prompts_question():


### PR DESCRIPTION
## Changes

This PR updates the CLI entry points so that they must be called with keyword arguments: this is how the `@command` plumbing works, so this makes it a bit clearer what's going on. (It also raises the bar to accidental breakage.)

### Tests

- existing unit tests
- existing integration tests
