### PR TITLE
Pass log-level to LSP server via environment

### DIFF
--- a/src/databricks/labs/lakebridge/transpiler/lsp/lsp_engine.py
+++ b/src/databricks/labs/lakebridge/transpiler/lsp/lsp_engine.py
@@ -473,7 +473,9 @@ class LSPEngine(TranspileEngine):
 
     async def _launch_executable(self, executable: str, args: Sequence[str], env: Mapping[str, str]) -> None:
         log_level = logging.getLevelName(logging.getLogger("databricks").level)
+        # TODO: Remove the --log_level argument once all our transpilers support the environment variable.
         args = [*args, f"--log_level={log_level}"]
+        env = {**env, "DATABRICKS_LAKEBRIDGE_LOG_LEVEL": log_level}
         logger.debug(f"Starting LSP engine: {executable} {args} (cwd={self._workdir})")
         await self._client.start_io(executable, *args, env=env, cwd=self._workdir)
 

--- a/tests/resources/lsp_transpiler/lsp_server.py
+++ b/tests/resources/lsp_transpiler/lsp_server.py
@@ -206,4 +206,7 @@ if __name__ == "__main__":
     sys.stderr.buffer.flush()
     logger.debug(f"SOME_ENV={os.getenv('SOME_ENV')}")
     logger.debug(f"sys.args={sys.argv}")
+    # Verifying only that the log-level is provided; we don't actually use it in this test server.
+    logger.debug(f"Requested log level: {os.getenv('DATABRICKS_LAKEBRIDGE_LOG_LEVEL')}")
+
     server.start_io()

--- a/tests/unit/transpiler/test_lsp_engine.py
+++ b/tests/unit/transpiler/test_lsp_engine.py
@@ -59,11 +59,18 @@ async def test_passes_extra_args(lsp_engine, transpile_config):
     assert "--stuff=12" in log  # see command_line in lsp_transpiler/config.yml
 
 
-async def test_passes_log_level(lsp_engine, transpile_config):
+async def test_passes_log_level_deprecated(lsp_engine, transpile_config):
     logging.getLogger("databricks").setLevel(logging.INFO)
     await lsp_engine.initialize(transpile_config)
     log = Path(path_to_resource("lsp_transpiler", "test-lsp-server.log")).read_text("utf-8")
     assert "--log_level=INFO" in log
+
+
+async def test_passes_log_level(lsp_engine, transpile_config):
+    logging.getLogger("databricks").setLevel(logging.INFO)
+    await lsp_engine.initialize(transpile_config)
+    log = Path(path_to_resource("lsp_transpiler", "test-lsp-server.log")).read_text("utf-8")
+    assert "Requested log level: INFO" in log
 
 
 async def test_receives_config(lsp_engine, transpile_config):

--- a/tests/unit/transpiler/test_lsp_engine.py
+++ b/tests/unit/transpiler/test_lsp_engine.py
@@ -63,7 +63,7 @@ async def test_passes_log_level(lsp_engine, transpile_config):
     logging.getLogger("databricks").setLevel(logging.INFO)
     await lsp_engine.initialize(transpile_config)
     log = Path(path_to_resource("lsp_transpiler", "test-lsp-server.log")).read_text("utf-8")
-    assert "--log_level=INFO" in log  # see command_line in lsp_transpiler/config.yml
+    assert "--log_level=INFO" in log
 
 
 async def test_receives_config(lsp_engine, transpile_config):


### PR DESCRIPTION
## Changes

Currently the requested log-level is supplied by the CLI to the LSP server via a hardcoded command-line option. This PR deprecates that mechanism in favour of passing it via the environment.

### Linked issues

Relates: #1918

### Functionality

- modified existing command: `databricks labs lakebridge transpile`

### Tests

- added unit tests
