### PR TITLE
Document internal transpiler repository interfaces

### DIFF
--- a/src/databricks/labs/lakebridge/cli.py
+++ b/src/databricks/labs/lakebridge/cli.py
@@ -318,7 +318,7 @@ class _TranspileConfigChecker:
                 return None
             case 1:
                 # Only one transpiler available for the specified dialect, use it.
-                transpiler_name = compatible_transpilers.pop()
+                transpiler_name = next(iter(compatible_transpilers))
                 logger.debug(f"Using only transpiler available for dialect {source_dialect!r}: {transpiler_name!r}")
             case _:
                 # Multiple transpilers available for the specified dialect, prompt for which to use.
@@ -361,7 +361,7 @@ class _TranspileConfigChecker:
                 raise_validation_exception(msg)
             case 1:
                 # Only one dialect available, use it.
-                source_dialect = supported_dialects.pop()
+                source_dialect = next(iter(supported_dialects))
                 logger.debug(f"Using only source dialect available: {source_dialect!r}")
             case _:
                 # Multiple dialects available, prompt for which to use.

--- a/src/databricks/labs/lakebridge/transpiler/lsp/lsp_engine.py
+++ b/src/databricks/labs/lakebridge/transpiler/lsp/lsp_engine.py
@@ -53,12 +53,12 @@ logger = logging.getLogger(__name__)
 @dataclass
 class _LSPRemorphConfigV1:
     name: str
-    dialects: list[str]
-    env_vars: dict[str, str]
-    command_line: list[str]
+    dialects: Sequence[str]
+    env_vars: Mapping[str, str]
+    command_line: Sequence[str]
 
     @classmethod
-    def parse(cls, data: dict[str, Any]) -> _LSPRemorphConfigV1:
+    def parse(cls, data: Mapping[str, Any]) -> _LSPRemorphConfigV1:
         version = data.get("version", 0)
         if version != 1:
             raise ValueError(f"Unsupported transpiler config version: {version}")
@@ -79,15 +79,15 @@ class _LSPRemorphConfigV1:
 class LSPConfig:
     path: Path
     remorph: _LSPRemorphConfigV1
-    options: dict[str, list[LSPConfigOptionV1]]
-    custom: dict[str, Any]
+    options: Mapping[str, Sequence[LSPConfigOptionV1]]
+    custom: Mapping[str, Any]
 
     @property
     def name(self):
         return self.remorph.name
 
-    def options_for_dialect(self, source_dialect: str) -> list[LSPConfigOptionV1]:
-        return self.options.get("all", []) + self.options.get(source_dialect, [])
+    def options_for_dialect(self, source_dialect: str) -> Sequence[LSPConfigOptionV1]:
+        return [*self.options.get("all", []), *self.options.get(source_dialect, [])]
 
     @classmethod
     def load(cls, path: Path) -> LSPConfig:
@@ -395,12 +395,12 @@ class LSPEngine(TranspileEngine):
     def transpiler_name(self) -> str:
         return self._config.name
 
-    def options_for_dialect(self, source_dialect: str) -> list[LSPConfigOptionV1]:
+    def options_for_dialect(self, source_dialect: str) -> Sequence[LSPConfigOptionV1]:
         """Get the options supported when transpiling a given source dialect."""
         return self._config.options_for_dialect(source_dialect)
 
     @property
-    def supported_dialects(self) -> list[str]:
+    def supported_dialects(self) -> Sequence[str]:
         return self._config.remorph.dialects
 
     @property

--- a/src/databricks/labs/lakebridge/transpiler/lsp/lsp_engine.py
+++ b/src/databricks/labs/lakebridge/transpiler/lsp/lsp_engine.py
@@ -107,10 +107,7 @@ class LSPConfig:
         return LSPConfig(path, remorph, options, custom)
 
 
-def lsp_feature(
-    name: str,
-    options: Any | None = None,
-):
+def lsp_feature(name: str, options: Any | None = None):
     def wrapped(func: Callable):
         _LSP_FEATURES.append((name, options, func))
         return func

--- a/src/databricks/labs/lakebridge/transpiler/repository.py
+++ b/src/databricks/labs/lakebridge/transpiler/repository.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping, Sequence, Set
 from json import loads
 import logging
 import os
@@ -56,45 +56,91 @@ class TranspilerRepository:
         return self._labs_path / "remorph-transpilers"
 
     def get_installed_version(self, product_name: str) -> str | None:
+        """
+        Obtain the version of an installed transpiler.
+
+        Args:
+          product_name: The product name of the transpiler whose version is sought.
+        Returns:
+          The version of the transpiler if it is installed, or None otherwise.
+        """
         # Warning: product_name here (eg. 'morpheus') and transpiler_name elsewhere (eg. Morpheus) are not the same!
         product_path = self.transpilers_path() / product_name
         current_version_path = product_path / "state" / "version.json"
-        if not current_version_path.exists():
+        try:
+            text = current_version_path.read_text("utf-8")
+        except FileNotFoundError:
             return None
-        text = current_version_path.read_text("utf-8")
         data: dict[str, Any] = loads(text)
         version: str | None = data.get("version", None)
         if not version or not version.startswith("v"):
             return None
         return version[1:]
 
-    def all_transpiler_configs(self) -> dict[str, LSPConfig]:
+    def all_transpiler_configs(self) -> Mapping[str, LSPConfig]:
+        """Obtain all installed transpile configurations.
+
+        Returns:
+          A mapping of configurations, keyed by their transpiler names.
+        """
         all_configs = self._all_transpiler_configs()
         return {config.name: config for config in all_configs}
 
-    def all_transpiler_names(self) -> set[str]:
+    def all_transpiler_names(self) -> Set[str]:
+        """Query the set of transpiler names for all installed transpilers."""
         all_configs = self.all_transpiler_configs()
-        return set(all_configs.keys())
+        return frozenset(all_configs.keys())
 
-    def all_dialects(self) -> set[str]:
+    def all_dialects(self) -> Set[str]:
+        """Query the set of dialects for all installed transpilers."""
         all_dialects: set[str] = set()
         for config in self._all_transpiler_configs():
             all_dialects = all_dialects.union(config.remorph.dialects)
         return all_dialects
 
-    def transpilers_with_dialect(self, dialect: str) -> set[str]:
+    def transpilers_with_dialect(self, dialect: str) -> Set[str]:
+        """
+        Query the set of transpilers that can handle a given dialect.
+
+        Args:
+          dialect: The dialect to check for.
+        Returns:
+          The set of transpiler names for installed transpilers that can handle a given dialect.
+        """
         configs = filter(lambda cfg: dialect in cfg.remorph.dialects, self.all_transpiler_configs().values())
-        return set(config.name for config in configs)
+        return frozenset(config.name for config in configs)
 
     def transpiler_config_path(self, transpiler_name: str) -> Path:
-        # Note: Can't just go straight to the directory: the transpiler names don't exactly match the directory names.
+        """
+        Obtain the path to a configuration file for an installed transpiler.
+
+        Args:
+          transpiler_name: The transpiler name of the transpiler whose path is sought.
+        Returns:
+          The path of the configuration file for the given installed transpiler. If multiple installed transpilers
+          have the same transpiler name, either may be returned.
+        Raises:
+          ValueError: If there is no installed transpiler with the given transpiler name.
+        """
+        # Note: Because it's the transpiler name, have to hunt through the installed list rather get it directly.
         try:
             config = next(c for c in self._all_transpiler_configs() if c.name == transpiler_name)
         except StopIteration as e:
             raise ValueError(f"No such transpiler: {transpiler_name}") from e
         return config.path
 
-    def transpiler_config_options(self, transpiler_name: str, source_dialect: str) -> list[LSPConfigOptionV1]:
+    def transpiler_config_options(self, transpiler_name: str, source_dialect: str) -> Sequence[LSPConfigOptionV1]:
+        """
+        Query the additional configuration options that are available for a given transpiler and source dialect that it
+        supports.
+
+        Args:
+          transpiler_name: The transpiler name of the transpiler that may provide options.
+          source_dialect: The source dialect supported by the given for which options are sought.
+        Returns:
+          A sequence of configuration options, possibly empty, that are supported by the given transpiler for the
+          specified source dialect.
+        """
         config = self.all_transpiler_configs().get(transpiler_name, None)
         if not config:
             return []  # gracefully returns an empty list, since this can only happen during testing

--- a/src/databricks/labs/lakebridge/transpiler/repository.py
+++ b/src/databricks/labs/lakebridge/transpiler/repository.py
@@ -22,6 +22,23 @@ class TranspilerRepository:
     via the `TranspilerRepository.user_home()` method.
     """
 
+    #
+    # Transpilers currently have different 'names', for historical reasons:
+    #
+    #  - product_name: the name of the product according to this project, assigned within the `installer` module and
+    #       used as the name of the directory into which the transpiler is installed within a repository.
+    #  - transpiler_name: the name of the product according to its own metadata, found in the configuration file
+    #       bundled within each transpiler as distributed.
+    #
+    # Note: multiple installed transpilers might have the same transpiler name, but a product name is unique to a single
+    # installed transpiler.
+    #
+    #  Known names at the moment:
+    #
+    #   - Morpheus:     product_name = databricks-morph-plugin,  transpiler_name = Morpheus
+    #   - BladeBridge:  product_name = bladebridge,              transpiler_name = Bladebridge
+    #
+
     @staticmethod
     def default_labs_path() -> Path:
         """Return the default path where labs applications are installed."""

--- a/src/databricks/labs/lakebridge/transpiler/transpile_engine.py
+++ b/src/databricks/labs/lakebridge/transpiler/transpile_engine.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import abc
+from collections.abc import Sequence
 from pathlib import Path
 
 from databricks.labs.lakebridge.config import TranspileResult, TranspileConfig
@@ -23,7 +24,7 @@ class TranspileEngine(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def supported_dialects(self) -> list[str]: ...
+    def supported_dialects(self) -> Sequence[str]: ...
 
     @abc.abstractmethod
     def is_supported_file(self, file: Path) -> bool: ...


### PR DESCRIPTION
## Changes

The primary goal of this PR is to clarify (and document) the different types of name a transpiler can have in the existing code-base. A secondary goal was to tighten some of the tight hints, in particular to limit collections to their read-only abstract interfaces.

Changes include:

 - Internal documentation for existing interfaces related to working with the transpiler repository.
 - Tighten type-hints to the read-only abstract collections.
 - Some minor code changes. (Called out inline, so they're visible.)

Out of scope: dealing with the inconsistencies and quirks of the naming that's in use.

### Tests

- existing unit tests
- existing integration tests