### PR TITLE
Fix stray `remorph` in product info (and user-agent)

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -20,7 +20,7 @@ def debug_env_name():
 
 @pytest.fixture
 def product_info():
-    return "lakebridge", __version__
+    return "lakebridge-integration-tests", __version__
 
 
 @pytest.fixture

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -19,7 +19,7 @@ def debug_env_name():
 
 
 @pytest.fixture
-def product_info():
+def product_info() -> tuple[str, str]:
     return "lakebridge-integration-tests", __version__
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -20,7 +20,7 @@ def debug_env_name():
 
 @pytest.fixture
 def product_info():
-    return "remorph", __version__
+    return "lakebridge", __version__
 
 
 @pytest.fixture


### PR DESCRIPTION
## Changes

When running integration tests, API calls include a `user-agent` header that includes product/version information. Prior to this PR, we were using:
```
remorph/0.10.8 databricks-sdk-py/0.51.0 python/3.10.18 os/darwin auth/azure-cli pytester/0.7.3 lsql/0.16.0 blueprint/0.11.3 lakebridge/0.10.8
```

By convention, the first pair is the product and the rest are libraries. This PR updates our integration tests so that they use:
```
lakebridge-integration-tests/0.10.8 databricks-sdk-py/0.51.0 python/3.10.18 os/darwin auth/azure-cli pytester/0.7.3 lsql/0.16.0 blueprint/0.11.3 lakebridge/0.10.8
```

(Side-effect, this also helps distinguish the source of the calls being made when problems occur.)

### Tests

- modified integration tests