### PR TITLE
Standardize schema queries

### DIFF
--- a/.github/scripts/setup_spark_remote.sh
+++ b/.github/scripts/setup_spark_remote.sh
@@ -13,7 +13,8 @@ fi
 
 spark=spark-${version}-bin-hadoop3
 spark_connect="spark-connect_2.12"
-
+mssql_jdbc_version="1.4.0"
+mssql_jdbc="spark-mssql-connector_2.12-${mssql_jdbc_version}-BETA"
 mkdir -p "${spark}"
 
 
@@ -29,6 +30,24 @@ else
     wget "https://downloads.apache.org/spark/spark-${version}/${spark}.tgz"
   fi
   tar -xvf "${spark}.tgz"
+fi
+
+JARS_DIR=$HOME/spark/${spark}/jars
+MSSQL_JDBC_JAR=$HOME/spark/${spark}/jars/${mssql_jdbc}.jar
+if [ -f "${MSSQL_JDBC_JAR}" ];then
+  echo "MSSQL JAR already exists"
+else
+  echo "Downloading MSSQL JAR and dependencies"
+  ## fixes ClassNotFoundException: com.microsoft.sqlserver.jdbc.SQLServerDriver
+  ## per https://github.com/microsoft/sql-spark-connector/issues/26#issuecomment-686155736
+  wget https://repo1.maven.org/maven2/com/microsoft/azure/adal4j/1.6.4/adal4j-1.6.4.jar -O "$JARS_DIR"/adal4j-1.6.4.jar
+  wget https://repo1.maven.org/maven2/com/nimbusds/oauth2-oidc-sdk/6.5/oauth2-oidc-sdk-6.5.jar -O "$JARS_DIR"/oauth2-oidc-sdk-6.5.jar
+  wget https://repo1.maven.org/maven2/com/google/code/gson/gson/2.8.0/gson-2.8.0.jar -O "$JARS_DIR"/gson-2.8.0.jar
+  wget https://repo1.maven.org/maven2/net/minidev/json-smart/1.3.1/json-smart-1.3.1.jar -O "$JARS_DIR"/json-smart-1.3.1.jar
+  wget https://repo1.maven.org/maven2/com/nimbusds/nimbus-jose-jwt/8.2.1/nimbus-jose-jwt-8.2.1.jar -O "$JARS_DIR"/nimbus-jose-jwt-8.2.1.jar
+  wget https://repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.21/slf4j-api-1.7.21.jar -O "$JARS_DIR"/slf4j-api-1.7.21.jar
+  wget https://repo1.maven.org/maven2/com/microsoft/sqlserver/mssql-jdbc/6.4.0.jre8/mssql-jdbc-6.4.0.jre8.jar -O "$JARS_DIR"/mssql-jdbc-6.4.0.jre8.jar
+  wget "https://github.com/microsoft/sql-spark-connector/releases/download/v${mssql_jdbc_version}/${mssql_jdbc}.jar" -O "$JARS_DIR"/${mssql_jdbc}.jar
 fi
 
 cd "${spark}" || exit 1

--- a/src/databricks/labs/lakebridge/reconcile/connectors/data_source.py
+++ b/src/databricks/labs/lakebridge/reconcile/connectors/data_source.py
@@ -49,7 +49,7 @@ class DataSource(ABC):
         Used in the implementations of get_schema to build a Schema DTO from the `INFORMATION_SCHEMA` query result.
         The returned Schema is normalized in case the database is having columns with special characters and standardize
         """
-        name = meta_column.col_name.lower()
+        name = meta_column.column_name.lower()
         dtype = meta_column.data_type.strip().lower()
         if normalize:
             normalized = self.normalize_identifier(name)

--- a/src/databricks/labs/lakebridge/reconcile/connectors/databricks.py
+++ b/src/databricks/labs/lakebridge/reconcile/connectors/databricks.py
@@ -26,7 +26,7 @@ def _get_schema_query(catalog: str, schema: str, table: str):
         return f"describe table {catalog}.{schema}.{table}"
 
     query = f"""select
-                            lower(column_name) as col_name,
+                            lower(column_name) as column_name,
                              full_data_type as data_type
                        from {catalog}.information_schema.columns
                        where lower(table_catalog)='{catalog}'

--- a/src/databricks/labs/lakebridge/reconcile/connectors/secrets.py
+++ b/src/databricks/labs/lakebridge/reconcile/connectors/secrets.py
@@ -6,7 +6,7 @@ from databricks.sdk.errors import NotFound
 
 logger = logging.getLogger(__name__)
 
-
+# TODO use CredentialManager to allow for changing secret provider for tests
 class SecretsMixin:
     _ws: WorkspaceClient
     _secret_scope: str

--- a/src/databricks/labs/lakebridge/reconcile/connectors/tsql.py
+++ b/src/databricks/labs/lakebridge/reconcile/connectors/tsql.py
@@ -18,7 +18,7 @@ from databricks.sdk import WorkspaceClient
 logger = logging.getLogger(__name__)
 
 _SCHEMA_QUERY = """SELECT
-                     COLUMN_NAME,
+                     COLUMN_NAME as 'column_name',
                      CASE
                         WHEN DATA_TYPE IN ('int', 'bigint')
                             THEN DATA_TYPE
@@ -39,7 +39,7 @@ _SCHEMA_QUERY = """SELECT
                         WHEN DATA_TYPE IN ('binary','varbinary')
                                 THEN 'binary'
                         ELSE DATA_TYPE
-                    END AS 'DATA_TYPE'
+                    END AS 'data_type'
                     FROM
                         INFORMATION_SCHEMA.COLUMNS
                     WHERE

--- a/tests/integration/reconcile/connectors/test_read_schema.py
+++ b/tests/integration/reconcile/connectors/test_read_schema.py
@@ -1,0 +1,27 @@
+from unittest.mock import create_autospec
+
+from databricks.labs.lakebridge.reconcile.connectors.tsql import TSQLServerDataSource
+from databricks.labs.lakebridge.transpiler.sqlglot.dialect_utils import get_dialect
+
+from databricks.sdk import WorkspaceClient
+
+from integration.connections.debug_envgetter import TestEnvGetter
+
+
+class TSQLServerDataSourceUnderTest(TSQLServerDataSource):
+    def __init__(self, engine, spark, ws, secret_scope):
+        super().__init__(engine, spark, ws, secret_scope)
+        self._test_env = TestEnvGetter(True)
+
+    @property
+    def get_jdbc_url(self) -> str:
+        return (self._test_env.get("TEST_TSQL_JDBC")
+                +f"user={self._test_env.get('TEST_TSQL_USER')};"
+                +f"password={self._test_env.get('TEST_TSQL_PASS')};")
+
+def test_tsql_server_read_schema_happy(mock_spark):
+    mock_ws = create_autospec(WorkspaceClient)
+    connector = TSQLServerDataSourceUnderTest(get_dialect("tsql"), mock_spark, mock_ws, "my_secret")
+
+    columns = connector.get_schema("labs_azure_sandbox_remorph", "dbo", "Employees")
+    assert columns


### PR DESCRIPTION
<!-- REMOVE IRRELEVANT COMMENTS BEFORE CREATING A PULL REQUEST -->
## Changes
<!-- Summary of your changes that are easy to understand. Add screenshots when necessary, they're helpful to illustrate the before and after state -->
### What does this PR do?
Fix reading schemas in reconcile 
### Relevant implementation details
* Use the same column names in all the data sources to DRY and allow using one mapper
* Add a sql server intergation spec
* Adapt local spark setup and add missing jars so integration spec can work
### Caveats/things to watch out for when reviewing:
* the mssql spark connector is legacy and the install is not well documented. the jar alone locally gives `ClassNotFoundException` and fixed by adding some missing dependencies
* In the future we should use our staging databricks for the integration tests to simplify local setup
### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [ ] added unit tests
- [X] added integration tests
