### PR TITLE
Support non-interactive installation of transpilers

### DIFF
--- a/labs.yml
+++ b/labs.yml
@@ -61,5 +61,8 @@ commands:
       - name: artifact
         description: Local path to transpiler artifact
         default: null
+      - name: interactive
+        description: "Whether installing in interactive mode, which may prompt for configuration settings."
+        default: auto
   - name: configure-reconcile
     description: "Configure Necessary Reconcile Dependencies"

--- a/src/databricks/labs/lakebridge/base_install.py
+++ b/src/databricks/labs/lakebridge/base_install.py
@@ -1,3 +1,5 @@
+import sys
+
 from databricks.labs.blueprint.logger import install_logger
 from databricks.labs.blueprint.entrypoint import get_logger
 from databricks.sdk import WorkspaceClient
@@ -18,6 +20,7 @@ def main() -> None:
     installer = _installer(
         WorkspaceClient(product="lakebridge", product_version=__version__),
         transpiler_repository=TranspilerRepository.user_home(),
+        is_interactive=sys.stdin.isatty(),
     )
     if not installer.upgrade_installed_transpilers():
         logger.debug("No existing Lakebridge transpilers detected; assuming fresh installation.")

--- a/src/databricks/labs/lakebridge/cli.py
+++ b/src/databricks/labs/lakebridge/cli.py
@@ -624,8 +624,8 @@ def install_transpile(
         ctx.add_user_agent_extra("artifact-overload", Path(artifact).name)
     user = w.current_user
     logger.debug(f"User: {user}")
-    transpile_installer = installer(w, transpiler_repository)
-    transpile_installer.run(module="transpile", artifact=artifact, is_interactive=is_interactive)
+    transpile_installer = installer(w, transpiler_repository, is_interactive=is_interactive)
+    transpile_installer.run(module="transpile", artifact=artifact)
 
 
 def interactive_mode(interactive: str | None, *, default: str = "auto", input_stream: TextIO = sys.stdin) -> bool:
@@ -660,7 +660,7 @@ def configure_reconcile(
         dbsql_id = _create_warehouse(w)
         w.config.warehouse_id = dbsql_id
     logger.debug(f"Warehouse ID used for configuring reconcile: {w.config.warehouse_id}.")
-    reconcile_installer = installer(w, transpiler_repository)
+    reconcile_installer = installer(w, transpiler_repository, is_interactive=True)
     reconcile_installer.run(module="reconcile")
 
 

--- a/src/databricks/labs/lakebridge/cli.py
+++ b/src/databricks/labs/lakebridge/cli.py
@@ -5,10 +5,11 @@ import json
 import logging
 import os
 import re
+import sys
 import time
 from collections.abc import Mapping
 from pathlib import Path
-from typing import NoReturn
+from typing import NoReturn, TextIO
 
 from databricks.sdk.service.sql import CreateWarehouseRequestWarehouseType
 from databricks.sdk import WorkspaceClient
@@ -612,9 +613,11 @@ def install_transpile(
     *,
     w: WorkspaceClient,
     artifact: str | None = None,
+    interactive: str | None = None,
     transpiler_repository: TranspilerRepository = TranspilerRepository.user_home(),
 ) -> None:
     """Install or upgrade the Lakebridge transpilers."""
+    is_interactive = interactive_mode(interactive)
     ctx = ApplicationContext(w)
     ctx.add_user_agent_extra("cmd", "install-transpile")
     if artifact:
@@ -622,7 +625,24 @@ def install_transpile(
     user = w.current_user
     logger.debug(f"User: {user}")
     transpile_installer = installer(w, transpiler_repository)
-    transpile_installer.run(module="transpile", artifact=artifact)
+    transpile_installer.run(module="transpile", artifact=artifact, is_interactive=is_interactive)
+
+
+def interactive_mode(interactive: str | None, *, default: str = "auto", input_stream: TextIO = sys.stdin) -> bool:
+    """Convert the raw '--interactive' argument into a boolean."""
+    if interactive is None:
+        interactive = default
+    match interactive.lower():
+        case "true":
+            return True
+        case "false":
+            return False
+        # Convention is that if the input_stream is a TTY, user interaction is allowed.
+        case "auto":
+            return input_stream.isatty()
+
+    msg = f"Invalid value for '--interactive': {interactive!r} must be 'true', 'false' or 'auto'."
+    raise_validation_exception(msg)
 
 
 @lakebridge.command(is_unauthenticated=False)

--- a/src/databricks/labs/lakebridge/install.py
+++ b/src/databricks/labs/lakebridge/install.py
@@ -166,7 +166,7 @@ class WorkspaceInstaller:
             )
 
         if not self._is_interactive:
-            logger.warning("Installation is not interactive, skipping `transpile` configuration.")
+            logger.warning("Installation is not interactive, skipping configuration of transpilers.")
             return None
 
         config = self._configure_new_transpile_installation()

--- a/src/databricks/labs/lakebridge/install.py
+++ b/src/databricks/labs/lakebridge/install.py
@@ -148,10 +148,13 @@ class WorkspaceInstaller:
     def _is_testing(self):
         return self._product_info.product_name() != "lakebridge"
 
-    def _configure_transpile(self) -> TranspileConfig:
+    def _configure_transpile(self) -> TranspileConfig | None:
         try:
             config = self._installation.load(TranspileConfig)
             logger.info("Lakebridge `transpile` is already installed on this workspace.")
+            if not self._is_interactive:
+                logger.debug("Installation is not interactive, keeping existing configuration.")
+                return config
             if not self._prompts.confirm("Do you want to override the existing installation?"):
                 return config
         except NotFound:
@@ -161,6 +164,10 @@ class WorkspaceInstaller:
             logger.warning(
                 f"Existing `transpile` installation at {install_dir} is corrupted. Continuing new installation..."
             )
+
+        if not self._is_interactive:
+            logger.warning("Installation is not interactive, skipping `transpile` configuration.")
+            return None
 
         config = self._configure_new_transpile_installation()
         logger.info("Finished configuring lakebridge `transpile`.")

--- a/src/databricks/labs/lakebridge/install.py
+++ b/src/databricks/labs/lakebridge/install.py
@@ -77,9 +77,15 @@ class WorkspaceInstaller:
         return frozenset(factory(self._transpiler_repository) for factory in self._transpiler_installer_factories)
 
     def run(
-        self, module: str, config: LakebridgeConfiguration | None = None, artifact: str | None = None
+        self,
+        module: str,
+        config: LakebridgeConfiguration | None = None,
+        artifact: str | None = None,
+        is_interactive: bool = True,
     ) -> LakebridgeConfiguration:
         logger.debug(f"Initializing workspace installation for module: {module} (config: {config})")
+        # TODO: Implement non-interactive mode.
+        _ = is_interactive
         if module == "transpile" and artifact:
             self._install_artifact(artifact)
         elif module in {"transpile", "all"}:

--- a/src/databricks/labs/lakebridge/install.py
+++ b/src/databricks/labs/lakebridge/install.py
@@ -49,6 +49,7 @@ class WorkspaceInstaller:
         workspace_installation: WorkspaceInstallation,
         environ: dict[str, str] | None = None,
         *,
+        is_interactive: bool = True,
         transpiler_repository: TranspilerRepository = TranspilerRepository.user_home(),
         transpiler_installers: Sequence[Callable[[TranspilerRepository], TranspilerInstaller]] = (
             BladebridgeInstaller,
@@ -62,6 +63,7 @@ class WorkspaceInstaller:
         self._product_info = product_info
         self._resource_configurator = resource_configurator
         self._ws_installation = workspace_installation
+        self._is_interactive = is_interactive
         self._transpiler_repository = transpiler_repository
         self._transpiler_installer_factories = transpiler_installers
 
@@ -81,11 +83,8 @@ class WorkspaceInstaller:
         module: str,
         config: LakebridgeConfiguration | None = None,
         artifact: str | None = None,
-        is_interactive: bool = True,
     ) -> LakebridgeConfiguration:
         logger.debug(f"Initializing workspace installation for module: {module} (config: {config})")
-        # TODO: Implement non-interactive mode.
-        _ = is_interactive
         if module == "transpile" and artifact:
             self._install_artifact(artifact)
         elif module in {"transpile", "all"}:
@@ -374,7 +373,12 @@ class WorkspaceInstaller:
         self._resource_configurator.has_necessary_access(catalog_name, schema_name, volume_name)
 
 
-def installer(ws: WorkspaceClient, transpiler_repository: TranspilerRepository) -> WorkspaceInstaller:
+def installer(
+    ws: WorkspaceClient,
+    transpiler_repository: TranspilerRepository,
+    *,
+    is_interactive: bool,
+) -> WorkspaceInstaller:
     app_context = ApplicationContext(_verify_workspace_client(ws))
     return WorkspaceInstaller(
         app_context.workspace_client,
@@ -385,6 +389,7 @@ def installer(ws: WorkspaceClient, transpiler_repository: TranspilerRepository) 
         app_context.resource_configurator,
         app_context.workspace_installation,
         transpiler_repository=transpiler_repository,
+        is_interactive=is_interactive,
     )
 
 

--- a/src/databricks/labs/lakebridge/install.py
+++ b/src/databricks/labs/lakebridge/install.py
@@ -63,6 +63,7 @@ class WorkspaceInstaller:
         self._product_info = product_info
         self._resource_configurator = resource_configurator
         self._ws_installation = workspace_installation
+        # TODO: Refactor the 'prompts' property in preference to using this flag, which should be redundant.
         self._is_interactive = is_interactive
         self._transpiler_repository = transpiler_repository
         self._transpiler_installer_factories = transpiler_installers

--- a/tests/integration/config/test_config.py
+++ b/tests/integration/config/test_config.py
@@ -1,3 +1,5 @@
+from databricks.sdk import WorkspaceClient
+
 from databricks.labs.blueprint.tui import MockPrompts
 from databricks.labs.lakebridge.config import TranspileConfig, ReconcileConfig
 from databricks.labs.lakebridge.contexts.application import ApplicationContext
@@ -10,7 +12,7 @@ class _WorkspaceInstaller(WorkspaceInstaller):
         self._save_config(config)
 
 
-def test_stores_and_fetches_config(ws):
+def test_stores_and_fetches_config(ws: WorkspaceClient) -> None:
     prompts = MockPrompts(
         {
             r"Open .* in the browser?": "no",

--- a/tests/unit/test_cli_other.py
+++ b/tests/unit/test_cli_other.py
@@ -1,5 +1,7 @@
-from unittest.mock import patch
+import io
+from unittest.mock import Mock, patch
 
+import pytest
 
 from databricks.labs.blueprint.tui import MockPrompts
 from databricks.labs.lakebridge import cli
@@ -19,6 +21,43 @@ def test_configure_secrets_databricks(mock_workspace_client):
     recon_conf.prompt_source()
 
     recon_conf.prompt_and_save_connection_details()
+
+
+@pytest.mark.parametrize(
+    ("argument", "expected"),
+    (
+        ("true", True),
+        ("tRuE", True),
+        ("false", False),
+        ("fAlSe", False),
+    ),
+)
+def test_interactive_argument(argument: str, expected: bool) -> None:
+    """Check that the simple --interactive arguments as expected."""
+    assert cli.interactive_mode(argument) is expected
+
+
+def test_interactive_argument_unknown() -> None:
+    """Check that an unknown --interactive argument raises an error."""
+    with pytest.raises(ValueError) as expected_error:
+        cli.interactive_mode("foobar")
+
+    assert str(expected_error.value) == "Invalid value for '--interactive': 'foobar' must be 'true', 'false' or 'auto'."
+
+
+@pytest.mark.parametrize("is_tty", (True, False))
+def test_interactive_argument_auto(is_tty: bool) -> None:
+    """Check that "auto" interactive detection is based on whether the stream looks like a TTY or not."""
+
+    # Set up a fake stdin. (Can't use pty: it's unavailable on Windows.)
+    mock_stdin = io.StringIO()
+    setattr(mock_stdin, "isatty", mock_isatty := Mock(return_value=is_tty))
+
+    interactive_mode = cli.interactive_mode("auto", input_stream=mock_stdin)
+
+    # Check that we queried whether it's a TTY and that the result is as expected.
+    assert mock_isatty.call_count == 1
+    assert interactive_mode is is_tty
 
 
 def test_cli_configure_secrets_config(mock_workspace_client):

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -1521,7 +1521,9 @@ def test_installer_upgrade_configure_if_changed(
 
 
 def test_no_reconfigure_if_noninteractive(
-    ws_installer: Callable[..., WorkspaceInstaller], ws: WorkspaceClient, caplog,
+    ws_installer: Callable[..., WorkspaceInstaller],
+    ws: WorkspaceClient,
+    caplog,
 ) -> None:
     """Check that when non-interactive we do not attempt to reconfigure if there is already a config."""
 
@@ -1566,7 +1568,9 @@ def test_no_reconfigure_if_noninteractive(
 
 
 def test_no_configure_if_noninteractive(
-    ws_installer: Callable[..., WorkspaceInstaller], ws: WorkspaceClient, caplog,
+    ws_installer: Callable[..., WorkspaceInstaller],
+    ws: WorkspaceClient,
+    caplog,
 ) -> None:
     """Check that when non-interactive we do not attempt configuration, even if there is no existing config."""
 
@@ -1575,7 +1579,7 @@ def test_no_configure_if_noninteractive(
     ctx = ApplicationContext(ws).replace(
         product_info=ProductInfo.for_testing(LakebridgeConfiguration),
         prompts=no_prompts_available,
-        installation=MockInstallation({})
+        installation=MockInstallation({}),
     )
 
     installer = ws_installer(

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -1518,3 +1518,79 @@ def test_installer_upgrade_configure_if_changed(
             "error_file_path": "/tmp/updated",
         }
         mock_installation.assert_file_written("config.yml", expected_configuration)
+
+
+def test_no_reconfigure_if_noninteractive(
+    ws_installer: Callable[..., WorkspaceInstaller], ws: WorkspaceClient, caplog,
+) -> None:
+    """Check that when non-interactive we do not attempt to reconfigure if there is already a config."""
+
+    no_prompts_available = MockPrompts({})
+
+    ctx = ApplicationContext(ws).replace(
+        product_info=ProductInfo.for_testing(LakebridgeConfiguration),
+        prompts=no_prompts_available,
+        installation=MockInstallation(
+            {
+                "config.yml": {
+                    "version": 3,
+                    "transpiler_config_path": PATH_TO_TRANSPILER_CONFIG,
+                    "source_dialect": "frobnicat",
+                    "input_source": "sf_queries",
+                    "output_folder": "out_dir",
+                    "error_file_path": "error_log.log",
+                    "skip_validation": True,
+                    "catalog_name": "remorph",
+                    "schema_name": "transpiler",
+                }
+            }
+        ),
+    )
+
+    installer = ws_installer(
+        ctx.workspace_client,
+        ctx.prompts,
+        ctx.installation,
+        ctx.install_state,
+        ctx.product_info,
+        ctx.resource_configurator,
+        ctx.workspace_installation,
+        is_interactive=False,
+    )
+    with caplog.at_level(logging.DEBUG):
+        config = installer.run(module="transpile")
+
+    assert config.transpile is not None
+    expected_log_message = "Installation is not interactive, keeping existing configuration."
+    assert any(expected_log_message in log.message for log in caplog.records if log.levelno == logging.DEBUG)
+
+
+def test_no_configure_if_noninteractive(
+    ws_installer: Callable[..., WorkspaceInstaller], ws: WorkspaceClient, caplog,
+) -> None:
+    """Check that when non-interactive we do not attempt configuration, even if there is no existing config."""
+
+    no_prompts_available = MockPrompts({})
+
+    ctx = ApplicationContext(ws).replace(
+        product_info=ProductInfo.for_testing(LakebridgeConfiguration),
+        prompts=no_prompts_available,
+        installation=MockInstallation({})
+    )
+
+    installer = ws_installer(
+        ctx.workspace_client,
+        ctx.prompts,
+        ctx.installation,
+        ctx.install_state,
+        ctx.product_info,
+        ctx.resource_configurator,
+        ctx.workspace_installation,
+        is_interactive=False,
+    )
+    with caplog.at_level(logging.WARNING):
+        config = installer.run(module="transpile")
+
+    assert config.transpile is None
+    expected_log_message = "Installation is not interactive, skipping configuration of transpilers."
+    assert any(expected_log_message in log.message for log in caplog.records if log.levelno == logging.WARNING)


### PR DESCRIPTION
## Changes

This PR implements `--interactive=false` for the `install-transpile` command. There are 3 possibilities with the new argument:

 - `--interactive=true`: The user can answer the prompts, if necessary.
 - `--interactive=false`: There is no user available to answer prompts.
 - `--interactive=auto`: The default, detect whether it looks like the command is being run in an interactive environment. (This is based on whether stdin is attached to a terminal or not.)

When non-interactive, the CLI behaviour changes:

 - If there is an existing configuration, it will always be left as-is.
 - If there is no existing configuration, we log a warning that this is the case.

Further to the changes with `install-transpile`, the configuration hooks during `databricks labs upgrade lakebridge` also run as if `--interactive=auto` was specified: configuration is skipped if it doesn't look we're running with a terminal.

### Relevant implementation details

Convention for Unix-like systems is to check whether stdin is attached to a terminal via the `isatty()` call. (This will be `False` if stdin is a pipe or reading from a file.) Python on Windows emulates this and detects whether it's running as a Console process.

This PR updates `WorkspaceInstaller` to have a boolean flag to indicate whether interaction is allowed; it would be better to refactor `Prompts` to account for non-interactive environments, but that would be a much larger set of changes. As such that's out of scope for now.

### Linked issues

Resolves #2007.

### Functionality

- updated existing commands:

   - `databricks labs lakebridge install-transpile`
   - `databricks labs upgrade lakebridge`

### Tests

- [x] manually tested
- [X] added unit tests
