### PR TITLE
Bump `actions/setup-node` from 4 to 5

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: yarn

--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: yarn


### PR DESCRIPTION
## Changes

This PR extends/mirrors #2003, but the CI checks will be able to complete. (Dependabot PRs do not have access to the acceptance environment.)