### PR TITLE
feat: add Switch transpiler integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 __pycache__
 dist
 .idea
+.vscode/
 /htmlcov/
 *.iml
 target/
@@ -22,3 +23,4 @@ remorph_transpile/
 /linter/src/main/antlr4/library/gen/
 .databricks-login.json
 .mypy_cache
+.env

--- a/docs/lakebridge/docs/overview.mdx
+++ b/docs/lakebridge/docs/overview.mdx
@@ -45,10 +45,11 @@ For migrating your SQL workloads we provide transpilers that can:
  - Translate SQL code from a variety of source platforms to Databricks SQL.
  - Translate some orchestration and ETL code to Databricks SQL.
 
-Internally, Lakebridge can use two different transpilers:
+Internally, Lakebridge can use three different transpilers:
 
  - *BladeBridge*, a mature transpiler that can handle a wide range of source dialects as well as some ETL/orchestration.
  - *Morpheus*, a next-generation transpiler that currently handles a smaller set of dialects, but includes experimental support for dbt.
+ - *Switch*, an LLM-powered transpiler that uses Large Language Models to convert SQL and other source formats to Databricks notebooks.
 
 The table below summarizes the source platforms that we currently support:
 

--- a/docs/lakebridge/docs/transpile/overview.mdx
+++ b/docs/lakebridge/docs/transpile/overview.mdx
@@ -88,7 +88,7 @@ It is important to note that the transpiler isn't always able to know whether it
 
 ## Plugins overview
 
-Out of the box, Lakebridge comes with two transpilation plugins: Morpheus and BladeBridge. Each one has its own set of capabilities and levels of guarantee that we describe below.
+Out of the box, Lakebridge comes with three transpilation plugins: Morpheus, BladeBridge, and Switch. Each one has its own set of capabilities and levels of guarantee that we describe below.
 
 ### Morpheus
 
@@ -133,6 +133,20 @@ Whether you're migrating a single job or thousands, BladeBridge delivers predict
 
 More details about the BladeBridge converter [here](/docs/transpile/pluggable_transpilers/bladebridge_overview)
 
+### Switch
+
+Switch is an LLM-powered Lakebridge transpiler that extends beyond SQL to convert various source formats into Databricks-compatible outputs. Using [Mosaic AI Model Serving](https://docs.databricks.com/aws/en/machine-learning/model-serving/), it understands code intent and semantics to handle complex transformations.
+
+Key characteristics:
+- **LLM-powered extensibility** - Built-in prompts for multiple SQL dialects (T-SQL, Snowflake, Teradata, Oracle, etc.) and generic formats (Python, Scala, Airflow)
+- **Custom prompt support** - Add YAML prompts to handle any source format not covered by built-in options  
+- **Flexible outputs** - Python notebooks with Spark SQL (default), SQL notebooks (experimental), or any text-based format
+- **Databricks-native processing** - Executes as scalable Lakeflow Jobs with serverless compute
+- **Model flexibility** - Choose any Model Serving endpoint to match your organization's requirements
+- **Complex logic handling** - Excels at stored procedures and business logic beyond ANSI SQL/PSM standards
+
+Switch's LLM-based approach enables support for any source format through custom prompts. For built-in prompt details and custom prompt creation, see the [Switch documentation](/docs/transpile/pluggable_transpilers/switch).
+
 ### Supported dialects
 
 | Source Platform              | Converter: BladeBridge | Converter: Morpheus | Output: SQL | Output: SparkSql | Output: PySpark | Other features available |
@@ -144,4 +158,3 @@ More details about the BladeBridge converter [here](/docs/transpile/pluggable_tr
 | Snowflake                    |             | &#x2705; | &#x2705; |         |         | dbt Repointing (Experimental) |
 | MS SQL Server (incl. Synapse)|  &#x2705;   | &#x2705; | &#x2705; |         |         |                             |
 | Teradata                     |  &#x2705;   |          | &#x2705; |         |         |                             |
-

--- a/docs/lakebridge/docs/transpile/pluggable_transpilers/index.mdx
+++ b/docs/lakebridge/docs/transpile/pluggable_transpilers/index.mdx
@@ -64,10 +64,11 @@ custom: # this section is optional, it is passed to the transpiler at startup
     <key 1>: <value 1> # can be pretty much anything
 ```
 
-Databricks provides 2 transpilers: _Morpheus_, its AST-based transpiler, and _BladeBridge_, a pattern-based transpiler.
+Databricks provides 3 transpilers: _Morpheus_, its AST-based transpiler, _BladeBridge_, a pattern-based transpiler, and _Switch_, an LLM-powered transpiler.
 These transpilers are installed by `Lakebridge` itself as part of running the `install-transpile` command, as follows:
  - the latest _Morpheus_ is fetched from [Maven Central](https://central.sonatype.com/), and installed at `.databricks/labs/remorph-transpilers/databricks-morph-plugin/`.
  - the latest _BladeBridge_ is fetched from [PyPi](https://pypi.org/), and installed at `.databricks/labs/remorph-transpilers/bladebridge/`.
+ - the latest _Switch_ is fetched from [PyPi](https://pypi.org/), and installed at `.databricks/labs/remorph-transpilers/switch/`.
 
 Installing 3rd party transpilers is the responsibility of their provider.
 

--- a/docs/lakebridge/docs/transpile/pluggable_transpilers/switch.mdx
+++ b/docs/lakebridge/docs/transpile/pluggable_transpilers/switch.mdx
@@ -1,0 +1,670 @@
+---
+title: Switch
+sidebar_position: 5
+---
+
+import CodeBlock from '@theme/CodeBlock';
+
+**Switch** is a Lakebridge transpiler plugin that uses Large Language Models (LLMs) to convert SQL and other source formats into Databricks notebooks or generic files. Switch leverages [Mosaic AI Model Serving](https://docs.databricks.com/aws/en/machine-learning/model-serving/) to understand code intent and semantics, generating equivalent Python notebooks with Spark SQL or other target formats.
+
+This LLM-powered approach excels at converting complex stored procedures, business logic, and ETL workflows where context and intent matter more than syntactic transformation. While generated notebooks may require manual adjustments, they provide a valuable foundation for Databricks migration.
+
+---
+
+## How Switch Works
+
+Switch operates through three key components that distinguish it from rule-based transpilers:
+
+### LLM-Powered Semantic Understanding
+Instead of parsing rules, Switch uses [Mosaic AI Model Serving](https://docs.databricks.com/aws/en/machine-learning/model-serving/) to:
+- Interpret code intent and business context beyond syntax
+- Handle SQL dialects, programming languages, and workflow definitions
+- Support complex logic patterns and proprietary extensions
+- Enable extensible conversion through custom YAML prompts
+
+### Native Databricks Integration
+Switch runs entirely within the Databricks workspace:
+- **Jobs API**: Executes as scalable Databricks Jobs for batch processing
+- **Model Serving**: Direct integration with Databricks LLM endpoints, with concurrent processing for multiple files
+- **Delta Tables**: Tracks conversion progress and results
+
+### Flexible Output Formats
+- **Notebooks**: Python notebooks containing Spark SQL (primary output)
+- **Generic Files**: YAML workflows, JSON configurations, and other text formats
+- **Experimental**: Additional SQL notebook output converted from generated Python notebooks
+
+---
+
+## Prerequisites & Requirements
+
+Before installing and using Switch, ensure your Databricks environment meets these requirements:
+
+### Databricks Workspace Setup
+
+**Job Execution Environment**
+- **Job Creation Permission**: Ability to create and manage Databricks Jobs
+  - A Switch job is automatically created during `install-transpile` execution
+- **Compute Access**: Switch creates jobs using serverless job compute by default
+  - If serverless is unavailable, you can modify job configuration in the Databricks workspace to use classic job compute
+
+**Data Storage Requirements**
+- **Catalog Access**: Existing catalog for Switch state management tables
+  - Unity Catalog catalogs (recommended) or Hive metastore catalogs supported
+- **Schema Access**: Existing schema within the specified catalog
+- **Table Creation Permission**: `CREATE TABLE` rights on the catalog and schema
+  - Switch creates Delta tables for conversion state and intermediate results
+  - Table naming: `lakebridge_switch_{timestamp}_{random}` (e.g., `lakebridge_switch_20250115143022_7ka9`)
+
+### Model Serving Access
+
+Switch uses Foundation Model APIs (like Claude) by default, with options for external model endpoints:
+
+- **Default Setup**: Uses Foundation Model API endpoints - no additional configuration required
+- **Permissions Required**: Query access to the model serving endpoint being used
+- **Custom Options**: Optionally configure external model endpoints or Provisioned Throughput for higher capacity
+
+### Databricks Runtime (for Classic Job Compute)
+- **Default**: Serverless job compute (no runtime configuration required)
+- **Classic Job Compute**: If using classic clusters instead of serverless:
+  - **Verified Versions**: DBR 14.3 LTS or 15.3 LTS (higher versions likely compatible)
+  - **Compute Type**: Single-node clusters recommended (Photon not required)
+
+---
+
+## Source Format Support
+
+Switch supports multiple source formats and provides built-in conversion prompts for various use cases.
+
+**Usage**: Specify the conversion type using the `--source-dialect` parameter with one of the values listed below.
+
+### SQL Sources (Default)
+
+Convert SQL from various dialects to Databricks Python notebooks with automatic comment removal and whitespace normalization.
+
+#### Built-in SQL Dialect Prompts
+
+| `--source-dialect` Value | Source Systems |
+|-------------|----------------|
+| `mssql` | Microsoft SQL Server, Azure SQL Database, Azure SQL Managed Instance, Amazon RDS for SQL Server |
+| `mysql` | MySQL, MariaDB, and MySQL-compatible services (including Amazon Aurora MySQL, RDS, Google Cloud SQL) |
+| `netezza` | IBM Netezza |
+| `oracle` | Oracle Database, Oracle Exadata, and Oracle-compatible services (including Amazon RDS) |
+| `postgresql` | PostgreSQL and PostgreSQL-compatible services (including Amazon Aurora PostgreSQL, RDS, Google Cloud SQL) |
+| `redshift` | Amazon Redshift |
+| `snowflake` | Snowflake |
+| `synapse` | Azure Synapse Analytics (dedicated SQL pools) |
+| `teradata` | Teradata |
+
+### Generic Sources
+
+Convert non-SQL files to notebooks or other formats without preprocessing.
+
+#### Built-in Generic Prompts
+
+| `--source-dialect` Value | Source → Target |
+|--------------|-----------------|
+| `python` | Python Script → Databricks Python Notebook |
+| `scala` | Scala Code → Databricks Python Notebook |
+| `airflow` | Airflow DAG → Databricks Jobs YAML + Operator conversion guidance (SQL→sql_task, Python→notebook, etc.) |
+
+### Custom Prompt Support
+
+Switch's LLM-based architecture supports additional conversion types through custom YAML conversion prompts, making it extensible beyond built-in options.
+
+For custom prompt creation, see the [Customizable Prompts](#customizable-prompts) section.
+
+---
+
+## Installation & Usage
+
+### Installation
+
+Switch integrates with the Lakebridge transpiler ecosystem:
+
+```bash
+databricks labs lakebridge install-transpile
+```
+
+The installation automatically:
+
+1. **Installs Switch**: Alongside other transpilers
+2. **Creates Databricks Job**: In your authenticated workspace  
+3. **Uploads Notebooks**: Switch processing notebooks to workspace
+
+Configuration is saved to:
+- **macOS/Linux**: `~/.databricks/labs/remorph-transpilers/switch/lib/config.yml`
+- **Windows**: `%USERPROFILE%\.databricks\labs\remorph-transpilers\switch\lib\config.yml`
+
+### CLI Usage
+
+Use the following command to run Switch. Specifying the Switch config file with `--transpiler-config-path` tells Lakebridge to use Switch as the transpiler. Add `--output json` for structured output with job monitoring details:
+
+```bash
+# Switch usage - SQL to notebooks conversion
+databricks labs lakebridge transpile \
+  --transpiler-config-path ~/.databricks/labs/remorph-transpilers/switch/lib/config.yml \
+  --input-source /Workspace/path/to/sql \
+  --output-folder /Workspace/path/to/notebooks \
+  --source-dialect snowflake \
+  --catalog-name your_existing_catalog \
+  --schema-name your_existing_schema \
+  --output json
+```
+
+When executing the above command, the response will look like this:
+
+```json
+{
+  "transpiler": "switch",
+  "job_id": 12345,
+  "run_id": 67890,
+  "run_url": "https://your-workspace.databricks.com/#job/12345/run/67890"
+}
+```
+
+For advanced configuration and conversion options (non-SQL sources, file outputs, etc.), see the [Advanced Configuration](#advanced-configuration) section below.
+
+#### Operational Notes
+
+Switch operates differently from other Lakebridge transpilers:
+
+- **Databricks Workspace Paths Required**: Input and output paths must be workspace paths (e.g., `/Workspace/path/to/...`) rather than local file paths
+- **Jobs API Execution**: Switch runs as a Databricks Job in your workspace, not as a local process
+- **Asynchronous by Default**: The command returns immediately with a job URL, allowing you to monitor progress in the Databricks workspace
+- **Monitoring**: Use the returned job URL to track conversion progress and view logs
+
+### CLI Parameters
+
+#### Required Parameters
+- `--transpiler-config-path` - Local path to Switch configuration file (identifies Switch as the transpiler)
+- `--input-source` - Databricks workspace path(s) or Unity Catalog Volume path(s) containing files to convert (see Input Source Patterns below)
+- `--output-folder` - Databricks workspace path for generated outputs
+- `--source-dialect` - Conversion type to use. Choose from:
+  - **SQL Dialects**: `mssql`, `mysql`, `netezza`, `oracle`, `postgresql`, `redshift`, `snowflake`, `synapse`, `teradata`
+  - **Generic sources**: `python`, `scala`, `airflow`
+- `--catalog-name` - Databricks catalog for state tables. Must already exist.
+- `--schema-name` - Databricks schema for state tables. Must already exist.
+  - Note: The user must have `CREATE TABLE` permissions on the specified catalog and schema for Switch's state management and intermediate result tables.
+
+#### Input Source Patterns
+
+The `--input-source` parameter supports flexible path specifications:
+
+| Pattern Type | Example | Description |
+|-------------|---------|-------------|
+| **Single Directory** | `/Workspace/path/to/sql` | Process all files in specified directory recursively |
+| **Multiple Directories** | `/Workspace/project1/sql,/Workspace/project2/sql` | Process files from multiple directories recursively (comma-separated) |
+| **Glob Patterns** | `/Workspace/Users/*/sql/*.sql` | Use wildcards to match paths (`*` = any characters, `**` = recursive) |
+| **Mixed Patterns** | `/Workspace/prod/**/*.sql,/Workspace/dev/sql` | Combine different pattern types |
+
+### Advanced Configuration
+
+Switch provides detailed configuration options that can be set by editing the `config.yml` file:
+
+| Parameter | Description | Default Value | Available Options |
+|-----------|-------------|---------------|-------------------|
+| `endpoint_name` | Model serving endpoint name | `databricks-claude-sonnet-4` | Any valid endpoint name |
+| `token_count_threshold` | Maximum tokens per file for processing | `20000` | Any positive integer |
+| `concurrency` | Number of parallel LLM requests | `4` | Any positive integer |
+| `comment_lang` | Language for generated comments | `English` | `English`, `Japanese`, `Chinese`, `French`, `German`, `Italian`, `Korean`, `Portuguese`, `Spanish` |
+| `max_fix_attempts` | Maximum syntax error fix attempts | `1` | 0 or any positive integer |
+| `log_level` | Logging verbosity level | `INFO` | `DEBUG`, `INFO`, `WARNING`, `ERROR` |
+| `source_format` | Source file format type. `sql` performs SQL comment removal and whitespace compression preprocessing. `generic` processes files as-is without preprocessing. | `sql` | `sql`, `generic` |
+| `target_type` | Output format type | `notebook` | `notebook`, `file` |
+| `output_extension` | File extension for file output | `<none>` | Any extension (e.g., `.yml`, `.json`) |
+| `conversion_prompt_yaml` | Custom conversion prompt YAML file path. When specified, this custom prompt is used instead of the built-in prompt for the selected `--source-dialect` | `<none>` | Full workspace path to YAML file |
+| `request_params` | Additional request parameters for model serving endpoint | `<none>` | JSON format string (e.g., `{"max_tokens": 64000}`) |
+| `sql_output_dir` | (Experimental) Directory for SQL notebooks | `<none>` | Full workspace path |
+| `wait_for_completion` | Wait for job completion. `true`=waits until job finishes, `false`=returns immediately with job URL | `false` | `true`, `false` |
+
+### How to Configure
+
+Modify `default:` values in the `config.yml` file and then execute `databricks labs lakebridge transpile`
+
+**Example config.yml modification**:
+```yaml
+- flag: comment_lang
+  default: "Japanese"     # Change from default "English" to "Japanese"
+```
+
+**Configuration for specific conversions**:
+- **Python script → Databricks Python notebook**: Set `source_format: "generic"`
+- **Airflow → Databricks Jobs YAML**: Set `source_format: "generic"`, `target_type: "file"`, `output_extension: ".yml"`
+
+---
+
+## Transpiler Selection Guide
+
+Lakebridge offers both LLM-powered and rule-based transpilers, each optimized for different conversion scenarios.
+
+### LLM-Powered Conversion (Switch)
+
+Switch is best suited for scenarios requiring semantic understanding and flexibility:
+- **Complex logic requiring contextual understanding** - Stored procedures and business logic where intent matters more than syntax
+- **Source formats not covered by rule-based transpilers** - Any SQL dialect or programming language through custom prompts
+- **Extensible conversion through custom YAML prompts** - Adapt to proprietary or uncommon source formats
+- **Python notebook output for SQL beyond ANSI SQL/PSM standards** - Complex transformations that benefit from procedural code
+
+### Rule-Based Conversion (BladeBridge & Morpheus)
+
+Rule-based transpilers excel in scenarios requiring consistency and speed:
+- **Deterministic output with guaranteed syntax equivalence** - Every conversion produces the same predictable result
+- **High-volume batch processing** - Efficiently handle thousands of files without API rate limits
+- **Fast local execution without API dependencies** - Sub-minute processing with no external service calls
+- **Production-grade SQL aligned with Databricks SQL evolution** - Leverages SQL Scripting, Stored Procedures, and latest DBSQL features
+
+### Key Decision Factors
+
+Consider these aspects when choosing between transpilers:
+- **Complexity**: Switch excels at complex logic requiring contextual understanding; rule-based transpilers handle standard SQL patterns efficiently
+- **Volume**: Rule-based transpilers process large volumes quickly; Switch is better for selective, complex conversions
+- **Customization**: Switch adapts to any source format through prompts; rule-based transpilers support specific, well-defined dialects
+- **Output format**: Switch primarily generates Python notebooks; rule-based transpilers produce SQL files
+
+### Best Practices for Switch
+
+When using Switch, follow these guidelines for optimal results:
+1. **Start with representative sample files** - Test conversion quality before processing entire codebase
+2. **Iteratively refine prompts based on results** - Adjust YAML prompts to improve accuracy for your specific patterns
+3. **Review generated code before production use** - LLM outputs may require manual adjustments
+4. **Document successful patterns for future reference** - Keep track of effective prompts and configurations for reuse
+
+---
+
+## Databricks Implementation Details
+
+When you run Switch via the CLI, it executes as Databricks Jobs using a sophisticated multi-stage processing pipeline. This section covers the internal architecture and configuration options.
+
+## Processing Architecture
+
+Switch executes as a Databricks Job that runs the main orchestration notebook (`00_main`), which routes to specialized orchestrators that coordinate the conversion pipeline:
+
+### Main Orchestration
+The **`00_main`** notebook serves as the entry point when Switch is executed via Databricks Jobs API. It:
+- Validates all input parameters from the job configuration
+- Routes execution to the appropriate orchestrator based on `target_type` (notebook or file output)
+- Handles orchestrator results and displays final conversion summary
+
+### Conversion Flow Overview
+
+Switch supports two target types with different processing workflows. The main entry point (`00_main`) routes to the appropriate orchestrator based on the `target_type` parameter:
+
+```mermaid
+flowchart TD
+    main["00_main (Entry Point)"] e1@==> decision{target_type?}
+    
+    decision e2@==>|notebook| notebookOrch["orchestrate_to_notebook (Full Processing Pipeline)"]
+    decision e3@==>|file| fileOrch["orchestrate_to_file (Simplified Processing Pipeline)"]
+    
+    notebookOrch e4@==> notebookFlow["7-Step Workflow: analyze → convert → validate → fix → split → export → sql_convert(optional)"]
+    fileOrch e5@==> fileFlow["3-Step Workflow: analyze → convert → export"]
+    
+    notebookFlow e6@==> notebookOutput[Python/SQL Notebooks]
+    fileFlow e7@==> fileOutput["Generic Files (YAML, JSON, etc.)"]
+    e1@{ animate: true }
+    e2@{ animate: true }
+    e3@{ animate: true }
+    e4@{ animate: true }
+    e5@{ animate: true }
+    e6@{ animate: true }
+    e7@{ animate: true }
+```
+
+### Notebook Conversion Flow
+
+For `target_type=notebook`, the `orchestrate_to_notebook` orchestrator executes a comprehensive 7-step processing pipeline:
+
+```mermaid
+flowchart TD
+    orchestrator[orchestrate_to_notebook] e1@==>|sequentially calls| processing
+    
+    subgraph processing ["Notebook Processing Workflow"]
+        direction TB
+        analyze[analyze_input_files] e2@==> convert[convert_with_llm]
+        convert e3@==> validate[validate_python_notebook]
+        validate e4@==> fix[fix_syntax_with_llm]
+        fix e5@==> split[split_code_into_cells]
+        split e6@==> export[export_to_notebook]
+        export -.-> sqlExport["convert_notebook_to_sql<br>(Optional)"]
+    end
+    
+    processing <-->|Read & Write| table[Conversion Result Table]
+    
+    convert -.->|Uses| endpoint[Model Serving Endpoint]
+    fix -.->|Uses| endpoint
+    sqlExport -.->|Uses| endpoint
+    
+    export e7@==> notebooks[Python Notebooks]
+    sqlExport -.-> sqlNotebooks["SQL Notebooks<br>(Optional Output)"]
+    e1@{ animate: true }
+    e2@{ animate: true }
+    e3@{ animate: true }
+    e4@{ animate: true }
+    e5@{ animate: true }
+    e6@{ animate: true }
+    e7@{ animate: true }
+```
+
+### File Conversion Flow
+
+For `target_type=file`, the `orchestrate_to_file` orchestrator uses a simplified 3-step processing pipeline optimized for generic file output:
+
+```mermaid
+flowchart TD
+    orchestrator[orchestrate_to_file] e1@==>|sequentially calls| processing
+    
+    subgraph processing ["File Processing Workflow"]
+        direction TB
+        analyze[analyze_input_files] e2@==> convert[convert_with_llm]
+        convert e3@==> export[export_to_file]
+    end
+    
+    processing <-->|Read & Write| table[Conversion Result Table]
+    
+    convert -.->|Uses| endpoint[Model Serving Endpoint]
+    
+    export e4@==> files["Generic Files (YAML, JSON, etc.)"]
+    e1@{ animate: true }
+    e2@{ animate: true }
+    e3@{ animate: true }
+    e4@{ animate: true }
+```
+
+**Key Differences:**
+- **File conversion skips** syntax validation, error fixing, and cell splitting steps
+- **Direct export** from converted content to specified file format with custom extension
+- **Optimized** for non-notebook outputs like YAML workflows, JSON configurations, etc.
+
+## Processing Steps
+
+The following sections describe each processing step used in the workflows above:
+
+### analyze_input_files
+Scans the input directory recursively and performs initial analysis. Stores all file contents, metadata, and analysis results in a timestamped Delta table. For SQL sources, creates preprocessed versions with comments removed and whitespace normalized in the table. Counts tokens using model-specific tokenizers (Claude uses ~3.4 characters per token, OpenAI and other models use tiktoken) to determine if files exceed the `token_count_threshold`. Files exceeding the threshold are excluded from conversion.
+
+### convert_with_llm  
+Loads conversion prompts (built-in or custom YAML) and sends file content to the configured model serving endpoint. Multiple files are processed concurrently (configurable, default: 4) for efficiency. The LLM transforms source code based on the conversion prompt, preserving business logic while adapting to Databricks patterns. For SQL sources, generates Python code with `spark.sql()` calls. For generic sources, adapts content to the specified target format.
+
+### validate_python_notebook
+Performs syntax validation on the generated code. Python syntax is checked using `ast.parse()`, while SQL statements within `spark.sql()` calls are validated using Spark's `EXPLAIN` command. Any errors are recorded in the result table for potential fixing in the next step.
+
+### fix_syntax_with_llm
+Attempts automatic error correction when syntax issues are detected. Sends error context back to the model serving endpoint, which suggests corrections. The validation and fix process repeats up to `max_fix_attempts` times (default: 1) until errors are resolved or the retry limit is reached.
+
+### split_code_into_cells
+Transforms raw converted Python code into well-structured notebook cells. Analyzes code flow and dependencies, splitting content at logical boundaries like imports, function definitions, and major operations. Adds appropriate markdown cells for documentation and readability.
+
+### export_to_notebook
+Creates Databricks-compatible `.py` notebooks in the specified output directory. Each notebook includes proper metadata, source file references, and any syntax check results as comments. Handles large files (up to 10MB) and preserves the original directory structure.
+
+### convert_notebook_to_sql (Optional)
+When `sql_output_dir` is specified, this optional step uses the model serving endpoint to convert Python notebooks into SQL notebook format with Databricks SQL syntax. Useful for teams preferring SQL-only workflows, though some Python logic may be lost in the conversion process.
+
+## Parameter Mapping
+
+When Switch executes as a Databricks Job, CLI parameters are mapped to notebook parameters:
+
+| CLI Parameter | Notebook Parameter | Description |
+|---------------|-------------------|-------------|
+| `--input-source` | `input_dir` | Workspace path(s) containing files to convert (supports patterns) |
+| `--output-folder` | `output_dir` | Workspace directory for generated outputs |
+| `--catalog-name` | `result_catalog` | Databricks catalog for state tracking tables |
+| `--schema-name` | `result_schema` | Databricks schema for state tracking tables |
+| `--source-dialect` | `builtin_prompt` | Conversion type (mapped to built-in prompt internally) |
+| `--transpiler-config-path` | (config file) | Path to Switch config file (loads additional parameters) |
+
+Additional parameters are configured through the Switch config file (see the [Advanced Configuration](#advanced-configuration) section above).
+
+## State Management
+
+Switch uses a Delta table to track conversion progress and results. Each conversion job creates a timestamped table: `{catalog}.{schema}.lakebridge_switch_{timestamp}_{random}` (e.g., `main.default.lakebridge_switch_20250115143022_7ka9`)
+
+The table stores input file information (path, content, token counts), conversion results (generated notebooks, token usage, processing time), error details when conversions fail, and syntax check results from validation stages. This allows you to monitor which files were processed successfully and investigate any issues that occurred during conversion.
+
+### Conversion Result Table Schema
+
+Switch creates Delta tables with the following complete schema:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `input_file_number` | int | Unique integer identifier for each input file (starts from 1) |
+| `input_file_path` | string | Full path to the input file |
+| `input_file_encoding` | string | Detected encoding of the input file (e.g., UTF-8) |
+| `tokenizer_type` | string | Type of tokenizer used (claude or openai) |
+| `tokenizer_model` | string | Specific tokenizer model/encoding used |
+| `input_file_token_count` | int | Total number of tokens in the input file |
+| `input_file_token_count_preprocessed` | int | Token count of preprocessed content (SQL comments removed for SQL files, original count for generic files) |
+| `input_file_content` | string | Entire content of the input file |
+| `input_file_content_preprocessed` | string | Preprocessed content (SQL comments removed for SQL files, original content for generic files) |
+| `is_conversion_target` | boolean | Whether file should be processed (updated during conversion) |
+| `model_serving_endpoint_for_conversion` | string | Model endpoint used for conversion |
+| `model_serving_endpoint_for_fix` | string | Model endpoint used for syntax error fixing |
+| `request_params_for_conversion` | string | Conversion request parameters in JSON format |
+| `request_params_for_fix` | string | Fix request parameters in JSON format |
+| `result_content` | string | Generated notebook content (initially null) |
+| `result_prompt_tokens` | int | Number of prompt tokens used (initially null) |
+| `result_completion_tokens` | int | Number of completion tokens generated (initially null) |
+| `result_total_tokens` | int | Total tokens used (prompt + completion, initially null) |
+| `result_processing_time_seconds` | float | Processing time in seconds (initially null) |
+| `result_timestamp` | timestamp | UTC timestamp when processing completed (initially null) |
+| `result_error` | string | Any conversion errors encountered (initially null) |
+| `result_python_parse_error` | string | Python syntax errors found using ast.parse (initially null) |
+| `result_extracted_sqls` | array&lt;string&gt; | SQL statements extracted from Python code (initially null) |
+| `result_sql_parse_errors` | array&lt;string&gt; | SQL syntax errors found using EXPLAIN (initially null) |
+| `export_output_path` | string | Path to the exported file (initially null) |
+| `export_status` | string | Export processing status (initially null) |
+| `export_error` | string | Export error information (initially null) |
+| `export_timestamp` | timestamp | UTC timestamp when export completed (initially null) |
+| `export_content_size_bytes` | long | Size of exported content in bytes (initially null) |
+
+## Model Requirements
+
+### Supported LLM Endpoints
+
+Switch offers flexible model selection - choose any Model Serving endpoint through configuration parameters.
+
+**Default Setup**  
+Pre-configured with an latest Claude model via Foundation Model API for immediate use (no configuration required). This ensures strong code comprehension and large context handling out of the box.
+
+**Model Options**  
+Switch works with LLMs that have large context windows and strong code comprehension capabilities:
+
+- **Foundation Model APIs**  
+  - Pay-per-token pricing for light usage  
+  - Provisioned Throughput for high-volume workloads with predictable cost and performance  
+
+- **External Models**  
+  - Support for any external model through Model Serving endpoints  
+  - Benefits include throughput control, organizational compliance (e.g., Azure-only policies), cost optimization, and higher concurrency limits  
+
+**Advanced Configuration**  
+For complex code transformations and intricate business logic, Claude’s extended thinking mode can significantly improve conversion accuracy. This mode allows the model to reason through complex transformations more thoroughly, though it increases processing time and token usage. Configure via `request_params`:
+
+```json
+{"max_tokens": 64000, "thinking": {"type": "enabled", "budget_tokens": 16000}}
+```
+
+### Token Management
+
+LLMs have limits on how much text they can process at once. Switch uses a configurable threshold approach to ensure stable processing.
+
+**Token Limits and Calculation:**
+- **Default threshold**: 20,000 tokens per file
+- **Token estimation**: 
+  - Claude models: ~3.4 characters per token (20,000 tokens ≈ 68,000 characters)
+  - Other models: Uses tiktoken library with o200k_base encoding
+- **Preprocessing**: SQL comments removed and whitespace compressed before counting
+
+**Threshold Configuration:**
+- **Base configuration**: 20,000 tokens (tested with Claude 3.7 Sonnet, 128k context)
+- **Adjustment guidelines**:
+  - Complex transformations with extended thinking: Lower threshold (e.g., 8,000 tokens)
+  - Larger context models (e.g., Claude Sonnet 4, 200k context): Higher threshold possible
+
+**Handling Oversized Files:**
+When files exceed the threshold:
+- Automatically excluded during analyze phase
+- Marked with status "Not converted"
+- Require manual splitting before processing
+
+**File Splitting Strategies:**
+If your input files exceed the threshold, consider logical splitting points:
+- Separate stored procedures into individual files
+- Split by functional modules or business domains
+- Maintain referential integrity across split files
+
+### Performance Optimization
+
+**Concurrency Settings:**
+- **Default concurrency**: Set to 4 based on testing with Claude models for stable operation
+- **Model-specific considerations**: Different foundation models have varying rate limits and optimal concurrency levels
+- **Scaling for large workloads**: For processing many files simultaneously, consider:
+  - **Increased concurrency**: Test higher values with your chosen model to find optimal settings
+  - **Provisioned Throughput**: Deploy dedicated Foundation Model API capacity with guaranteed throughput
+  - **External Models**: Configure external endpoints with higher rate limits
+
+**Monitoring:**
+- Watch for rate limiting or throttling responses from model endpoints
+- Consider enabling [Inference Tables](https://docs.databricks.com/aws/en/machine-learning/model-serving/inference-tables) to automatically capture requests and responses for detailed monitoring and debugging
+
+---
+
+## Customizable Prompts
+
+You can create custom conversion prompts for Switch to handle new SQL dialects or specialized conversion requirements.
+
+### Creating Custom Conversion Prompts
+
+To create a custom conversion prompt:
+
+1. **Create a YAML file** with the required structure
+2. **Place it in your Databricks workspace**
+3. **Specify the full path** in the `conversion_prompt_yaml` parameter
+
+Custom conversion prompts require two main sections:
+
+#### Required Structure
+
+Here's a simple example showing the basic structure of a custom conversion prompt:
+
+```yaml
+system_message: |
+  Convert SQL code to Python code that runs on Databricks according to the following instructions:
+
+  # Input and Output
+  - Input: A single SQL file containing one or multiple T-SQL statements
+  - Output: Python code with Python comments (in {comment_lang}) explaining the code
+
+  ${common_python_instructions_and_guidelines}
+
+  # Additional Instructions
+  1. Convert SQL queries to spark.sql() format
+  2. Add clear Python comments explaining the code
+  3. Use DataFrame operations instead of loops when possible
+  4. Handle errors using try-except blocks
+
+few_shots:
+- role: user
+  content: |
+    SELECT name, age
+    FROM users
+    WHERE active = 1;
+- role: assistant
+  content: |
+    # Get names and ages of active users
+    active_users = spark.sql("""
+        SELECT name, age
+        FROM users
+        WHERE active = 1
+    """)
+    display(active_users)
+```
+
+#### Key Elements
+
+**`system_message` Section**:
+- Clear explanation of the conversion purpose
+- Definition of input and output formats
+- Additional instructions for specific conversions
+- (Optional) Comment language specification (`{comment_lang}` will be replaced automatically by Switch)
+- (Optional) Common instructions placeholder (`${common_python_instructions_and_guidelines}` will be replaced automatically by Switch with built-in conversion guidelines)
+
+**`few_shots` Section** (Optional but recommended):
+- Include examples ranging from simple to complex cases
+- Each example demonstrates specific patterns for LLM understanding
+- Shows typical conversion patterns for your SQL dialect
+
+### Reference: Built-in YAML Files
+
+Switch includes built-in YAML configuration files for supported conversion types, including SQL dialects and other source formats. When creating custom prompts, these built-in configurations serve as excellent starting points - even for supported conversion types, customizing the default prompts based on your specific input patterns can significantly improve conversion accuracy.
+
+**Location**: You can find built-in YAML files in the `switch/resources/builtin_prompts/` directory within the Switch installation. These files demonstrate the proper structure and provide conversion-specific examples that you can adapt for your custom requirements.
+
+### FAQ: Can Switch Support My Source System?
+
+A common question is whether Switch can handle sources beyond the built-in conversion types. The answer is: **try it!**
+
+Switch already supports various source formats including SQL dialects (MySQL, Snowflake, Oracle, etc.), programming languages (Python scripts, Scala code), and workflows (Airflow DAGs).
+
+**For SQL-based sources**: Creating a custom prompt YAML file should work well for most SQL dialects. Since LLMs understand SQL syntax patterns, you can typically achieve good results by:
+- Starting with a similar built-in dialect's YAML as a template
+- Adding specific syntax examples from your source system
+- Testing and iterating based on results
+
+**Tips for efficient prompt creation:**
+- **Quick baseline creation**: Feed built-in prompts and your source dialect's representative features to an advanced LLM to quickly generate a baseline YAML configuration
+- **Dialect-specific patterns**: Reference open source projects like [SQLGlot dialects](https://github.com/tobymao/sqlglot/tree/main/sqlglot/dialects) for insights into dialect-specific transformation patterns
+
+**For other source formats**: Switch's LLM-based architecture means it can potentially handle various conversions beyond the built-in types. Modern LLMs have strong comprehension capabilities across many languages and formats. You can experiment by:
+- Creating custom prompts that define your source format
+- Providing clear conversion examples in the few-shots section
+- Testing with representative source samples
+
+Rather than waiting for additional built-in examples, we encourage experimentation with custom prompts. The flexibility of LLM-based conversion means many use cases are possible with the right prompt engineering.
+
+## Conversion Results and Troubleshooting
+
+### Understanding Conversion Results
+
+After your Switch job completes, review the conversion results displayed at the end of the `00_main` notebook execution. The results table shows the status of each input file:
+
+- **Successfully converted files**: Ready to use as Databricks notebooks
+- **Files requiring attention**: May need manual review or re-processing
+
+If you encounter files that didn't convert successfully, here are the most common issues and their solutions:
+
+### Files Not Converting (Status: `Not converted`)
+
+These files were skipped during the conversion process, typically because they're too large for the model to process effectively.
+
+**Cause**: Input files exceed the token count threshold
+
+**Solutions**:
+- Split large input files into smaller, more manageable parts
+- Increase the `token_count_threshold` parameter if your LLM model can handle larger inputs
+
+### Conversion with Errors (Status: `Converted with errors`)
+
+These files were successfully processed by the LLM but the generated code contains syntax errors that need to be addressed.
+
+**Cause**: Files were converted but contain syntax errors
+
+**Solutions**:
+- Review syntax error messages in the result table's error_details column
+- Manually fix errors in the converted notebooks/files
+- Increase `max_fix_attempts` for more automatic error correction attempts
+
+### Export Failures (Status: `Export failed` or `Not exported`)
+
+These files were converted successfully but couldn't be exported to the output directory.
+
+**Causes**: 
+- Content exceeds 10MB size limit of Databricks notebooks
+- File system permissions issues
+- Invalid output paths
+
+**Solutions**:
+- Check the `export_error` column in the result table for specific error details
+- For size issues: Manually split large converted content into smaller units
+- For permission issues: Verify workspace access to the output directory
+- For path issues: Ensure output directory paths are valid workspace locations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
   "SQLAlchemy~=2.0.40",
   "pygls~=2.0.0a2",
   "duckdb~=1.2.2",
+  "databricks-switch-plugin>=0.1.0",
 ]
 
 [project.urls]
@@ -84,7 +85,8 @@ dependencies = [
   "pandas-stubs~=2.3.0.250703",
   "cattrs>=25.2.0",
   "click<8.3.0", # https://github.com/pallets/click/issues/3065 for ruff
-  "faker"
+  "faker",
+  "python-dotenv"
 ]
 
 [project.entry-points.databricks]

--- a/src/databricks/labs/lakebridge/install.py
+++ b/src/databricks/labs/lakebridge/install.py
@@ -28,6 +28,7 @@ from databricks.labs.lakebridge.reconcile.constants import ReconReportType, Reco
 from databricks.labs.lakebridge.transpiler.installers import (
     BladebridgeInstaller,
     MorpheusInstaller,
+    SwitchInstaller,
     TranspilerInstaller,
 )
 from databricks.labs.lakebridge.transpiler.repository import TranspilerRepository
@@ -51,9 +52,10 @@ class WorkspaceInstaller:
         *,
         is_interactive: bool = True,
         transpiler_repository: TranspilerRepository = TranspilerRepository.user_home(),
-        transpiler_installers: Sequence[Callable[[TranspilerRepository], TranspilerInstaller]] = (
+        transpiler_installers: Sequence[Callable[[TranspilerRepository, WorkspaceClient], TranspilerInstaller]] = (
             BladebridgeInstaller,
             MorpheusInstaller,
+            SwitchInstaller,
         ),
     ):
         self._ws = ws
@@ -77,7 +79,9 @@ class WorkspaceInstaller:
 
     @property
     def _transpiler_installers(self) -> Set[TranspilerInstaller]:
-        return frozenset(factory(self._transpiler_repository) for factory in self._transpiler_installer_factories)
+        return frozenset(
+            factory(self._transpiler_repository, self._ws) for factory in self._transpiler_installer_factories
+        )
 
     def run(
         self,

--- a/tests/integration/switch/test_e2e.py
+++ b/tests/integration/switch/test_e2e.py
@@ -1,0 +1,519 @@
+"""E2E tests for Switch transpiler integration with Lakebridge
+
+This module provides end-to-end testing for Switch conversion functionality
+through Lakebridge CLI.
+
+Test Classes:
+1. TestSwitchInstallationLifecycle: Installation workflow testing
+   - test_installation_lifecycle: Test install → reinstall → uninstall operations
+
+2. TestLakebridgeSwitchConversion: SQL and code conversion tests
+   - test_sql_basic_conversion: Snowflake → Databricks
+   - test_sql_advanced_conversion: MSSQL → Databricks with advanced parameters
+   - test_airflow_file_conversion: Airflow DAG → YAML file
+
+Environment Variables:
+- DATABRICKS_HOST & DATABRICKS_TOKEN: Workspace credentials (required)
+- LAKEBRIDGE_SWITCH_E2E=true: Enable E2E tests (disabled by default)
+- LAKEBRIDGE_SWITCH_E2E_CLEAN_ALL_BEFORE=true: Clean up existing resources before tests
+- LAKEBRIDGE_SWITCH_E2E_KEEP_AFTER=true: Keep resources after tests (for debugging)
+- LAKEBRIDGE_SWITCH_E2E_CATALOG: Custom catalog name (default: "main")
+- LAKEBRIDGE_SWITCH_E2E_WAREHOUSE_ID: SQL warehouse ID for schema operations (required)
+
+Note: Schema names are automatically generated with timestamp + random suffix to prevent conflicts.
+
+Usage:
+    # Quick async test (4 tests, ~2-3 minutes)
+    LAKEBRIDGE_SWITCH_E2E=true pytest tests/integration/switch/test_e2e.py -v
+"""
+
+import logging
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from switch.testing.e2e_utils import SwitchCleanupManager, SwitchSchemaManager
+
+from databricks.labs.lakebridge import cli
+from databricks.labs.lakebridge.config import TranspileConfig
+from databricks.labs.lakebridge.contexts.application import ApplicationContext
+from databricks.labs.lakebridge.deployment.installation import WorkspaceInstallation
+from databricks.labs.lakebridge.transpiler.installers import SwitchInstaller
+from databricks.labs.lakebridge.transpiler.repository import TranspilerRepository
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.errors import NotFound
+from databricks.sdk.service.workspace import ImportFormat
+
+logger = logging.getLogger(__name__)
+
+# Load environment variables
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv()
+except ImportError:
+    pass
+
+
+@dataclass
+class LakebridgeTestConfig:
+    """Unified configuration for Lakebridge E2E tests"""
+
+    warehouse_id: str
+    test_schema: str
+    catalog: str = "main"
+    clean_all_before: bool = False
+    keep_after: bool = False
+
+    @classmethod
+    def from_env(cls) -> "LakebridgeTestConfig":
+        """Create configuration from environment variables"""
+        warehouse_id = os.getenv("LAKEBRIDGE_SWITCH_E2E_WAREHOUSE_ID")
+        if not warehouse_id:
+            raise ValueError("LAKEBRIDGE_SWITCH_E2E_WAREHOUSE_ID environment variable is required")
+
+        return cls(
+            catalog=os.getenv("LAKEBRIDGE_SWITCH_E2E_CATALOG", "main"),
+            clean_all_before=os.getenv("LAKEBRIDGE_SWITCH_E2E_CLEAN_ALL_BEFORE") == "true",
+            keep_after=os.getenv("LAKEBRIDGE_SWITCH_E2E_KEEP_AFTER") == "true",
+            warehouse_id=warehouse_id,
+            test_schema="",  # Will be generated during test setup
+        )
+
+
+# Test configuration constants
+BASE_DIR_PREFIX = ".e2e-lakebridge-switch"
+EXAMPLES_DIR_SUFFIX = "-examples"
+SCHEMA_PREFIX = "e2e_lakebridge_switch"
+
+
+@pytest.mark.skipif(
+    os.getenv("LAKEBRIDGE_SWITCH_E2E") != "true",
+    reason="Switch E2E tests disabled. Set LAKEBRIDGE_SWITCH_E2E=true to enable",
+)
+class TestSwitchInstallationLifecycle:
+    """Switch installation lifecycle tests (independent execution)"""
+
+    @pytest.fixture(scope="class")
+    def workspace_client(self):
+        """Create Databricks workspace client for E2E tests"""
+        host = os.getenv("DATABRICKS_HOST")
+        token = os.getenv("DATABRICKS_TOKEN")
+
+        if not (host and token):
+            pytest.skip("Databricks credentials required. Set DATABRICKS_HOST and DATABRICKS_TOKEN")
+
+        return WorkspaceClient(host=host, token=token)
+
+    def test_installation_lifecycle(self, workspace_client):
+        """Test complete installation workflow: install → reinstall → uninstall"""
+        logger.info("Starting installation lifecycle test")
+
+        # Step 1: Install Switch
+        logger.info("Step 1: Installing Switch transpiler")
+        job_id1 = self._install_switch(workspace_client)
+        assert job_id1 is not None, "Initial installation should succeed"
+        logger.info(f"Switch installed successfully with job ID: {job_id1}")
+
+        # Step 2: Reinstall (test cleanup of previous installation)
+        logger.info("Step 2: Testing reinstallation with cleanup")
+        job_id2 = self._install_switch(workspace_client)
+        assert job_id2 is not None, "Reinstallation should succeed"
+        assert job_id2 != job_id1, "New job ID should be different from old one"
+        logger.info(f"Reinstallation successful. Old job {job_id1} cleaned up, new job {job_id2} created")
+
+        # Step 3: Uninstall and verify
+        logger.info("Step 3: Testing uninstallation")
+        self._uninstall_switch(workspace_client)
+        assert _get_switch_job_id() is None, "Switch config should be removed"
+        assert not _verify_job_exists(workspace_client, job_id2), f"Job {job_id2} should be deleted"
+        logger.info("Uninstallation successful")
+
+    # ==================== Helper Methods for Installation Tests ====================
+
+    def _install_switch(self, workspace_client: WorkspaceClient) -> int | None:
+        """Install Switch for testing"""
+        logger.info("Installing Switch transpiler")
+
+        try:
+            # Install using new SwitchInstaller pattern
+            transpiler_repository = TranspilerRepository.user_home()
+            switch_installer = SwitchInstaller(transpiler_repository, workspace_client)
+            switch_installer.install()
+            logger.info("Switch installation completed")
+        except Exception as e:
+            logger.error(f"Switch installation failed: {e}")
+            raise ValueError(f"Failed to install Switch: {e}") from e
+
+        # Verify installation
+        job_id = _get_switch_job_id()
+        if job_id is None:
+            raise ValueError("Switch job ID not found after installation")
+
+        if not _verify_job_exists(workspace_client, job_id):
+            raise ValueError(f"Switch job {job_id} not found in workspace")
+
+        logger.info(f"Switch installed with job ID: {job_id}")
+        return job_id
+
+    def _uninstall_switch(self, workspace_client: WorkspaceClient):
+        """Uninstall Switch using main WorkspaceInstallation method"""
+        try:
+            # Create WorkspaceInstallation instance
+            workspace_installation = WorkspaceInstallation(
+                ws=workspace_client,
+                prompts=None,  # type: ignore[arg-type]
+                installation=None,  # type: ignore[arg-type]
+                recon_deployment=None,  # type: ignore[arg-type]
+                product_info=None,  # type: ignore[arg-type]
+                upgrades=None,  # type: ignore[arg-type]
+            )
+            # Call the main uninstall method
+            workspace_installation.uninstall_switch()
+            logger.info("Switch uninstalled using main WorkspaceInstallation method")
+        except Exception as e:
+            logger.error(f"Failed to use main uninstall method: {e}")
+            raise ValueError(f"Failed to uninstall Switch: {e}") from e
+
+
+@pytest.mark.e2e
+@pytest.mark.skipif(
+    os.getenv("LAKEBRIDGE_SWITCH_E2E") != "true",
+    reason="Switch E2E tests disabled. Set LAKEBRIDGE_SWITCH_E2E=true to enable",
+)
+class TestLakebridgeSwitchConversion:
+    """Lakebridge-Switch conversion tests with shared setup/teardown"""
+
+    # Class-level shared resources
+    workspace_client: WorkspaceClient
+    cleanup_manager: SwitchCleanupManager | None = None
+    schema_manager: SwitchSchemaManager
+    job_id: int
+    examples_base_dir: str | None = None
+    test_resources_dir: Path
+    config: LakebridgeTestConfig
+
+    @classmethod
+    def setup_class(cls):
+        """Setup orchestrator following conftest.py pattern"""
+        if not cls._setup_environment_and_config():
+            return
+        if cls.config.clean_all_before:
+            cls._cleanup_resources()
+        cls._setup_resources()
+
+    @classmethod
+    def teardown_class(cls):
+        """Teardown orchestrator following conftest.py pattern"""
+        if not cls.config.keep_after:
+            cls._cleanup_resources()
+
+    @classmethod
+    def _setup_environment_and_config(cls) -> bool:
+        """Setup environment, credentials, and validate requirements
+
+        Returns:
+            bool: True if setup successful, False if should skip tests
+        """
+        # Get configuration
+        cls.config = LakebridgeTestConfig.from_env()
+
+        # Check all requirements at once
+        host = os.getenv("DATABRICKS_HOST")
+        token = os.getenv("DATABRICKS_TOKEN")
+
+        if not (host and token):
+            pytest.skip("Databricks credentials required. Set DATABRICKS_HOST and DATABRICKS_TOKEN")
+        if not cls.config.warehouse_id:
+            pytest.skip("LAKEBRIDGE_SWITCH_E2E_WAREHOUSE_ID required for schema operations")
+
+        # Initialize workspace client after all validations
+        cls.workspace_client = WorkspaceClient(host=host, token=token)
+        return True
+
+    @classmethod
+    def _setup_resources(cls) -> None:
+        """Setup new resources: schema, Switch installation, examples"""
+        # Setup NEW resources AFTER cleanup
+        # Initialize schema manager and generate unique test schema
+        cls.schema_manager = SwitchSchemaManager(cls.workspace_client, cls.config.warehouse_id)
+        test_schema = cls.schema_manager.generate_unique_schema_name(SCHEMA_PREFIX)
+
+        # Create test schema
+        logger.info(f"Creating test schema: {cls.config.catalog}.{test_schema}")
+        cls.schema_manager.create_schema(cls.config.catalog, test_schema)
+        cls.config.test_schema = test_schema
+
+        # Install Switch once
+        logger.info("Setting up Switch for all conversion tests")
+        cls.job_id = cls._ensure_switch_installed_class(cls.workspace_client)
+
+        # Build name for examples base directory
+        current_user = cls.workspace_client.current_user.me().user_name
+        cls.examples_base_dir = f"/Workspace/Users/{current_user}/{BASE_DIR_PREFIX}{EXAMPLES_DIR_SUFFIX}"
+
+        # Set up test resources directory
+        cls.test_resources_dir = Path(__file__).parent.parent.parent / "resources" / "switch"
+
+        # Upload examples once
+        logger.info(f"Uploading examples to {cls.examples_base_dir}")
+        cls._upload_test_examples()
+
+    @classmethod
+    def _cleanup_resources(cls) -> None:
+        """Cleanup resources (always runs when called)"""
+        logger.info("Cleaning up resources")
+
+        # Initialize cleanup manager if needed
+        if not cls.cleanup_manager:
+            cls.cleanup_manager = SwitchCleanupManager(cls.workspace_client, cls.config.warehouse_id)
+
+        # Comprehensive cleanup (jobs, schemas, tables, etc.)
+        try:
+            cls.cleanup_manager.cleanup_all_if_requested(cls.config.catalog, prefix=SCHEMA_PREFIX)
+        except (ValueError, RuntimeError, OSError) as e:
+            logger.warning(f"Cleanup failed: {e}")
+
+        # Clean up test directories
+        if cls.examples_base_dir and cls.workspace_client:
+            try:
+                cls.workspace_client.workspace.delete(cls.examples_base_dir, recursive=True)
+            except (ValueError, RuntimeError, OSError) as e:
+                logger.warning(f"Failed to delete examples directory: {e}")
+
+    @classmethod
+    def _upload_test_examples(cls) -> None:
+        """Upload test examples from local resources to workspace"""
+        # Upload entire test resources directory using switch e2e_utils pattern
+        if cls.examples_base_dir is None:
+            raise RuntimeError("examples_base_dir not initialized")
+        cls._upload_directory_to_workspace(cls.test_resources_dir, cls.examples_base_dir)
+
+    @classmethod
+    def _upload_directory_to_workspace(cls, local_dir: Path, workspace_dir: str) -> None:
+        """Upload a local directory to workspace"""
+        if not local_dir.exists():
+            logger.warning(f"Local directory {local_dir} does not exist, skipping")
+            return
+
+        logger.info(f"Uploading {local_dir} -> {workspace_dir}")
+
+        # Create workspace directory
+        cls.workspace_client.workspace.mkdirs(workspace_dir)
+
+        # Upload all files recursively
+        file_count = 0
+        for file_path in local_dir.rglob("*"):
+            if file_path.is_file():
+                # Calculate relative path to maintain directory structure
+                relative_path = file_path.relative_to(local_dir)
+                workspace_file_path = f"{workspace_dir}/{relative_path}"
+
+                # Create parent directories if needed
+                workspace_parent = "/".join(workspace_file_path.split("/")[:-1])
+                if workspace_parent != workspace_dir.rstrip("/"):
+                    cls.workspace_client.workspace.mkdirs(workspace_parent)
+
+                # Upload file
+                with open(file_path, "rb") as f:
+                    content = f.read()
+                cls.workspace_client.workspace.upload(
+                    path=workspace_file_path, content=content, format=ImportFormat.AUTO, overwrite=True
+                )
+                logger.info(f"  ✓ Uploaded: {workspace_file_path}")
+                file_count += 1
+
+        logger.info(f"  Directory upload completed: {file_count} files")
+
+    @classmethod
+    def _ensure_switch_installed_class(cls, workspace_client: WorkspaceClient) -> int:
+        """Ensure Switch is installed and return job ID"""
+        job_id = _get_switch_job_id()
+        if job_id is not None and _verify_job_exists(workspace_client, job_id):
+            logger.info(f"Switch already installed with job ID: {job_id}")
+            return job_id
+
+        logger.info("Installing Switch")
+        return cls._install_switch_class(workspace_client)
+
+    @classmethod
+    def _install_switch_class(cls, workspace_client: WorkspaceClient) -> int:
+        """Install Switch for testing"""
+        logger.info("Installing Switch transpiler")
+
+        try:
+            # Install using new SwitchInstaller pattern
+            transpiler_repository = TranspilerRepository.user_home()
+            switch_installer = SwitchInstaller(transpiler_repository, workspace_client)
+            switch_installer.install()
+            logger.info("Switch installation completed")
+        except Exception as e:
+            logger.error(f"Switch installation failed: {e}")
+            raise ValueError(f"Failed to install Switch: {e}") from e
+
+        # Verify installation
+        job_id = _get_switch_job_id()
+        if job_id is None:
+            raise ValueError("Switch job ID not found after installation")
+
+        if not _verify_job_exists(workspace_client, job_id):
+            raise ValueError(f"Switch job {job_id} not found in workspace")
+
+        logger.info(f"Switch installed with job ID: {job_id}")
+        return job_id
+
+    def test_sql_basic_conversion(self):
+        """Basic SQL conversion: Snowflake → Databricks (async)"""
+        current_user = self.workspace_client.current_user.me().user_name
+
+        try:
+            # Execute conversion using shared resources
+            input_dir = f"{self.examples_base_dir}/sql/snowflake"
+            output_dir = f"/Workspace/Users/{current_user}/{BASE_DIR_PREFIX}-basic-output-{int(time.time())}"
+
+            result = self._execute_conversion(
+                workspace_client=self.workspace_client,
+                source_dialect="snowflake",
+                input_source=input_dir,
+                output_folder=output_dir,
+                catalog_name=self.config.catalog,
+                schema_name=self.config.test_schema,
+            )
+
+            # Verify result
+            self._verify_conversion_result(result)
+            logger.info("Basic SQL conversion test completed successfully")
+        except Exception as e:
+            logger.error(f"Basic SQL conversion test failed: {e}")
+            raise
+
+    def test_sql_advanced_conversion(self):
+        """Advanced SQL conversion: MSSQL → Databricks with advanced parameters (async)"""
+        current_user = self.workspace_client.current_user.me().user_name
+
+        try:
+            # Execute conversion with advanced parameters using shared resources
+            input_dir = f"{self.examples_base_dir}/sql/mssql"
+            output_dir = f"/Workspace/Users/{current_user}/{BASE_DIR_PREFIX}-advanced-output-{int(time.time())}"
+            sql_output_dir = f"/Workspace/Users/{current_user}/{BASE_DIR_PREFIX}-advanced-sql-{int(time.time())}"
+
+            result = self._execute_conversion(
+                workspace_client=self.workspace_client,
+                source_dialect="mssql",
+                input_source=input_dir,
+                output_folder=output_dir,
+                catalog_name=self.config.catalog,
+                schema_name=self.config.test_schema,
+                extra_options={
+                    "log_level": "DEBUG",
+                    "comment_lang": "Japanese",
+                    "token_count_threshold": "25000",
+                    "sql_output_dir": sql_output_dir,
+                    "max_fix_attempts": "1",
+                },
+            )
+
+            # Verify result
+            self._verify_conversion_result(result)
+            logger.info("Advanced SQL conversion test completed successfully")
+        except Exception as e:
+            logger.error(f"Advanced SQL conversion test failed: {e}")
+            raise
+
+    def test_airflow_file_conversion(self):
+        """Airflow DAG to YAML file conversion with generic source format (async)"""
+        current_user = self.workspace_client.current_user.me().user_name
+
+        try:
+            # Execute conversion using shared resources
+            input_dir = f"{self.examples_base_dir}/workflow/airflow"
+            output_dir = f"/Workspace/Users/{current_user}/{BASE_DIR_PREFIX}-airflow-output-{int(time.time())}"
+
+            result = self._execute_conversion(
+                workspace_client=self.workspace_client,
+                source_dialect="airflow",
+                input_source=input_dir,
+                output_folder=output_dir,
+                catalog_name=self.config.catalog,
+                schema_name=self.config.test_schema,
+                extra_options={"source_format": "generic", "target_type": "file", "output_extension": ".yml"},
+            )
+
+            # Verify result
+            self._verify_conversion_result(result)
+            logger.info("Airflow file conversion test completed successfully")
+        except Exception as e:
+            logger.error(f"Airflow file conversion test failed: {e}")
+            raise
+
+    # ==================== Helper Methods for Conversion Tests ====================
+
+    def _execute_conversion(
+        self,
+        workspace_client: WorkspaceClient,
+        source_dialect: str,
+        input_source: str,
+        output_folder: str,
+        catalog_name: str,
+        schema_name: str,
+        extra_options: dict[str, str] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Execute Lakebridge conversion (always async)"""
+        # Prepare transpiler options
+        transpiler_options = extra_options if extra_options else {}
+
+        # Create TranspileConfig
+        transpiler_config_path = str(TranspilerRepository.user_home().transpiler_config_path("switch"))
+        transpile_config = TranspileConfig(
+            transpiler_config_path=transpiler_config_path,
+            source_dialect=source_dialect,
+            input_source=input_source,
+            output_folder=output_folder,
+            catalog_name=catalog_name,
+            schema_name=schema_name,
+            skip_validation=True,
+            transpiler_options=transpiler_options,  # type: ignore[arg-type]
+        )
+
+        # Execute via Lakebridge CLI (always async)
+        ctx = ApplicationContext(workspace_client)
+        switch_handler = cli.SwitchTranspilerHandler(ctx)
+        return switch_handler.run_job(transpile_config)
+
+    def _verify_conversion_result(self, result: list[dict[str, Any]]):
+        """Verify conversion result (async only)"""
+        assert isinstance(result, list), "Result should be a list"
+        assert len(result) == 1, "Result should contain exactly one item"
+
+        result_item = result[0]
+        assert result_item["transpiler"] == "switch", "Transpiler should be 'switch'"
+        assert "job_id" in result_item, "Result should contain job_id"
+        assert "run_id" in result_item, "Result should contain run_id"
+        assert "run_url" in result_item, "Result should contain run_url"
+
+
+# ==================== Common Helper Functions ====================
+
+
+def _get_switch_job_id() -> int | None:
+    """Get Switch job ID from config"""
+    switch_config = TranspilerRepository.user_home().all_transpiler_configs().get("switch")
+    if switch_config:
+        return switch_config.custom.get("job_id")
+    return None
+
+
+def _verify_job_exists(workspace_client: WorkspaceClient, job_id: int) -> bool:
+    """Check if Databricks job exists"""
+    try:
+        job = workspace_client.jobs.get(job_id)
+        return job is not None
+    except NotFound:
+        return False
+    except (ValueError, RuntimeError, OSError) as e:
+        logger.error(f"Error checking job {job_id}: {e}")
+        return False

--- a/tests/resources/switch/sql/mssql/sample.sql
+++ b/tests/resources/switch/sql/mssql/sample.sql
@@ -1,0 +1,27 @@
+-- Sample MSSQL for E2E testing
+-- This is a minimal test file to verify Switch conversion functionality
+
+SELECT 
+    c.customer_id,
+    c.customer_name,
+    o.order_date,
+    o.total_amount
+FROM customers c
+INNER JOIN orders o ON c.customer_id = o.customer_id
+WHERE o.order_date >= '2024-01-01'
+ORDER BY o.order_date DESC;
+
+-- Test stored procedure conversion
+CREATE PROCEDURE UpdateCustomerStatus
+    @CustomerId INT,
+    @NewStatus NVARCHAR(50)
+AS
+BEGIN
+    SET NOCOUNT ON;
+    
+    UPDATE customers 
+    SET status = @NewStatus 
+    WHERE customer_id = @CustomerId;
+    
+    SELECT 'Customer status updated successfully' AS Result;
+END;

--- a/tests/resources/switch/sql/snowflake/sample.sql
+++ b/tests/resources/switch/sql/snowflake/sample.sql
@@ -1,0 +1,24 @@
+-- Sample Snowflake SQL for E2E testing
+-- This is a minimal test file to verify Switch conversion functionality
+
+SELECT 
+    customer_id,
+    customer_name,
+    order_date,
+    total_amount
+FROM customers c
+JOIN orders o ON c.customer_id = o.customer_id
+WHERE order_date >= '2024-01-01'
+ORDER BY order_date DESC;
+
+-- Test stored procedure conversion
+CREATE OR REPLACE PROCEDURE update_customer_status(customer_id INT, new_status STRING)
+RETURNS STRING
+LANGUAGE SQL
+AS
+$$
+BEGIN
+    UPDATE customers SET status = :new_status WHERE id = :customer_id;
+    RETURN 'Customer status updated successfully';
+END;
+$$;

--- a/tests/resources/switch/workflow/airflow/sample_dag.py
+++ b/tests/resources/switch/workflow/airflow/sample_dag.py
@@ -1,0 +1,62 @@
+"""
+Sample Airflow DAG for E2E testing
+This is a minimal test file to verify Switch conversion functionality
+"""
+
+from datetime import datetime, timedelta
+from airflow import DAG
+from airflow.operators.python_operator import PythonOperator
+from airflow.operators.bash_operator import BashOperator
+
+# Default arguments for the DAG
+default_args = {
+    'owner': 'data_team',
+    'depends_on_past': False,
+    'start_date': datetime(2024, 1, 1),
+    'email_on_failure': False,
+    'email_on_retry': False,
+    'retries': 1,
+    'retry_delay': timedelta(minutes=5),
+}
+
+# Define the DAG
+dag = DAG(
+    'sample_etl_pipeline',
+    default_args=default_args,
+    description='Sample ETL pipeline for testing',
+    schedule_interval=timedelta(days=1),
+    catchup=False,
+)
+
+
+def extract_data(**context):
+    """Extract data from source"""
+    print("Extracting data from source system...")
+    return "extracted_data"
+
+
+def transform_data(**context):
+    """Transform extracted data"""
+    print("Transforming data...")
+    return "transformed_data"
+
+
+def load_data(**context):
+    """Load data to destination"""
+    print("Loading data to destination...")
+    return "data_loaded"
+
+
+# Define tasks
+extract_task = PythonOperator(task_id='extract_data', python_callable=extract_data, dag=dag)
+
+transform_task = PythonOperator(task_id='transform_data', python_callable=transform_data, dag=dag)
+
+load_task = PythonOperator(task_id='load_data', python_callable=load_data, dag=dag)
+
+validation_task = BashOperator(
+    task_id='validate_data', bash_command='echo "Data validation completed successfully"', dag=dag
+)
+
+# Define task dependencies
+extract_task >> transform_task >> load_task >> validation_task

--- a/tests/unit/switch/conftest.py
+++ b/tests/unit/switch/conftest.py
@@ -1,0 +1,204 @@
+"""Shared test fixtures and configuration for Switch unit tests"""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+import yaml
+
+
+@pytest.fixture
+def switch_config_data():
+    """Shared Switch configuration data matching actual config.yml"""
+    return {
+        "remorph": {
+            "version": 1,
+            "name": "switch",
+            "command_line": ["echo", "Switch uses Jobs API, not LSP"],
+            "dialects": [
+                "mssql",
+                "mysql",
+                "netezza",
+                "oracle",
+                "postgresql",
+                "redshift",
+                "snowflake",
+                "synapse",
+                "teradata",
+                "python",
+                "scala",
+                "airflow",
+            ],
+        },
+        "options": {
+            "all": [
+                {
+                    "flag": "source_format",
+                    "method": "CHOICE",
+                    "prompt": "Source file format",
+                    "choices": ["sql", "generic"],
+                    "default": "sql",
+                },
+                {
+                    "flag": "target_type",
+                    "method": "CHOICE",
+                    "prompt": "Target output type",
+                    "choices": ["notebook", "file"],
+                    "default": "notebook",
+                },
+                {
+                    "flag": "output_extension",
+                    "method": "QUESTION",
+                    "prompt": "Output file extension (for file target type) - press <enter> for none",
+                    "default": "<none>",
+                },
+                {
+                    "flag": "endpoint_name",
+                    "method": "QUESTION",
+                    "prompt": "Model endpoint name",
+                    "default": "databricks-claude-sonnet-4",
+                },
+                {"flag": "concurrency", "method": "QUESTION", "prompt": "Concurrency level", "default": 4},
+                {"flag": "max_fix_attempts", "method": "QUESTION", "prompt": "Maximum fix attempts", "default": 1},
+                {
+                    "flag": "log_level",
+                    "method": "CHOICE",
+                    "prompt": "Log level",
+                    "choices": ["DEBUG", "INFO", "WARNING", "ERROR"],
+                    "default": "INFO",
+                },
+                {
+                    "flag": "token_count_threshold",
+                    "method": "QUESTION",
+                    "prompt": "Token count threshold",
+                    "default": 20000,
+                },
+                {
+                    "flag": "comment_lang",
+                    "method": "CHOICE",
+                    "prompt": "Comment language",
+                    "choices": [
+                        "English",
+                        "Japanese",
+                        "Chinese",
+                        "French",
+                        "German",
+                        "Italian",
+                        "Korean",
+                        "Portuguese",
+                        "Spanish",
+                    ],
+                    "default": "English",
+                },
+                {
+                    "flag": "conversion_prompt_yaml",
+                    "method": "QUESTION",
+                    "prompt": "Custom conversion prompt YAML file path - press <enter> for default",
+                    "default": "<none>",
+                },
+                {
+                    "flag": "sql_output_dir",
+                    "method": "QUESTION",
+                    "prompt": "SQL output directory - press <enter> for none",
+                    "default": "<none>",
+                },
+                {
+                    "flag": "request_params",
+                    "method": "QUESTION",
+                    "prompt": "Additional request parameters (JSON) - press <enter> for none",
+                    "default": "<none>",
+                },
+                {
+                    "flag": "wait_for_completion",
+                    "method": "CHOICE",
+                    "prompt": "Wait for job completion?",
+                    "choices": ["true", "false"],
+                    "default": "false",
+                },
+            ]
+        },
+        "custom": {
+            "execution_type": "jobs_api",
+            "job_id": 12345,
+            "job_name": "lakebridge-switch",
+            "job_url": "https://test.databricks.com/jobs/12345",
+            "switch_home": "/Workspace/Users/test/.lakebridge-switch",
+            "created_by": "test@databricks.com",
+        },
+    }
+
+
+@pytest.fixture
+def switch_config_path(switch_config_data):
+    """Create a temporary Switch config file for testing"""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+
+        # Create Switch config structure
+        switch_dir = temp_path / "switch" / "lib"
+        switch_dir.mkdir(parents=True)
+
+        config_path = switch_dir / "config.yml"
+        with config_path.open("w") as f:
+            yaml.dump(switch_config_data, f)
+
+        # Patch TranspilerRepository to use temp directory
+        with patch(
+            "databricks.labs.lakebridge.transpiler.repository.TranspilerRepository.transpilers_path",
+            return_value=temp_path,
+        ):
+            with patch(
+                "databricks.labs.lakebridge.transpiler.repository.TranspilerRepository.all_transpiler_names",
+                return_value={"switch"},
+            ):
+                # Create mock LSPConfig object
+                mock_switch_config = MagicMock()
+                mock_switch_config.custom = switch_config_data.get("custom", {})
+                mock_switch_config.options = switch_config_data.get("options", {})
+                with patch(
+                    "databricks.labs.lakebridge.transpiler.repository.TranspilerRepository.all_transpiler_configs",
+                    return_value={"switch": mock_switch_config},
+                ):
+                    yield config_path
+
+
+@pytest.fixture
+def mock_application_context():
+    """Create a mock ApplicationContext for testing"""
+    mock_ctx = MagicMock()
+    mock_ctx.workspace_client = MagicMock()
+    mock_ctx.workspace_client.config.host = "https://test.databricks.com"
+    return mock_ctx
+
+
+@pytest.fixture
+def mock_workspace_client():
+    """Create a mock WorkspaceClient for testing"""
+    mock_ws = MagicMock()
+    mock_ws.config.host = "https://test.databricks.com"
+    return mock_ws
+
+
+@pytest.fixture
+def mock_install_result():
+    """Mock SwitchInstaller.install() result"""
+    result = MagicMock()
+    result.job_id = 123456789
+    result.job_name = "lakebridge-switch"
+    result.job_url = "https://test.databricks.com/jobs/123456789"
+    result.switch_home = "/Workspace/Users/test/.lakebridge-switch"
+    result.created_by = "test@databricks.com"
+    return result
+
+
+def setup_transpiler_repository_mock(mock_repo, tmp_path, config_path, config_data):
+    """Setup common TranspilerRepository mock configuration"""
+    mock_repo.transpilers_path.return_value = tmp_path
+    mock_repo.transpiler_config_path.return_value = config_path
+
+    mock_switch_config = MagicMock()
+    mock_switch_config.custom = config_data.get("custom", {})
+    mock_repo.all_transpiler_configs.return_value = {"switch": mock_switch_config}
+
+    return mock_repo

--- a/tests/unit/switch/test_cli.py
+++ b/tests/unit/switch/test_cli.py
@@ -1,0 +1,228 @@
+"""Unit tests for Switch transpiler CLI functionality
+
+Tests how Lakebridge CLI handles Switch transpiler differently from local transpilers.
+Switch uses Databricks Jobs API instead of local execution, requiring special handling.
+
+Focus: CLI integration layer (not end-to-end SQL conversion)
+Approach: Lightweight mocking to test interface contracts
+Execution time: ~5-10 seconds
+
+Test coverage:
+- test_switch_detection:
+    Validates Switch availability detection and routing logic
+
+- test_switch_parameter_mapping:
+    Validates TranspileConfig to SwitchJobParameters conversion with new features
+
+- test_switch_parameter_integration:
+    Tests new parameters (source_format, target_type, builtin_prompt)
+
+- test_switch_cli_integration_flow:
+    Tests CLI correctly delegates to Switch job execution (lightweight, async only)
+
+- test_switch_error_handling:
+    Tests error handling for missing Switch package and configuration issues
+"""
+
+import logging
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from switch.api.job_parameters import SwitchJobParameters
+
+from databricks.labs.lakebridge import cli
+from databricks.labs.lakebridge.config import TranspileConfig
+from databricks.labs.lakebridge.transpiler.repository import TranspilerRepository
+
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def valid_transpile_config(switch_config_path):
+    """Create a valid TranspileConfig for Switch execution"""
+    return TranspileConfig(
+        transpiler_config_path=str(switch_config_path),
+        source_dialect="snowflake",
+        input_source="/Workspace/Users/test/sql_input",
+        output_folder="/Workspace/Users/test/notebooks_output",
+        catalog_name="test_catalog",
+        schema_name="test_schema",
+    )
+
+
+class TestSwitchCLIIntegration:
+    """Test how Lakebridge CLI integrates with Switch transpiler"""
+
+    def test_switch_detection(self, switch_config_path, mock_application_context):
+        """Test that Switch is properly detected when installed"""
+        # When Switch config exists, it should be detected
+        switch_handler = cli.SwitchTranspilerHandler(mock_application_context)
+        is_switch_request = switch_handler.should_handle(str(switch_config_path))
+        assert is_switch_request is True, "Switch should be detected when config exists"
+
+        # Verify Switch appears in available transpilers
+        all_transpilers = TranspilerRepository.user_home().all_transpiler_names()
+        assert "switch" in all_transpilers, "Switch should appear in transpiler list"
+
+    def test_switch_routing_decision(self, switch_config_path, mock_application_context):
+        """Test the decision logic for using Switch Jobs API path"""
+        # Test with Switch config path
+        switch_config = TranspileConfig(
+            transpiler_config_path=str(switch_config_path),
+            source_dialect="snowflake",
+            input_source="/test/input",
+            output_folder="/test/output",
+        )
+
+        # Should route to Switch when available and requested
+        switch_handler = cli.SwitchTranspilerHandler(mock_application_context)
+        assert switch_handler.should_handle(switch_config.transpiler_config_path) is True
+
+        # Test with non-Switch transpiler
+        non_switch_config = TranspileConfig(
+            transpiler_config_path="/path/to/morpheus/config.yml",
+            source_dialect="snowflake",
+            input_source="/test/input",
+            output_folder="/test/output",
+        )
+
+        assert switch_handler.should_handle(non_switch_config.transpiler_config_path) is False
+
+    def test_switch_parameter_mapping(self, valid_transpile_config, mock_application_context):
+        """Test conversion from TranspileConfig to SwitchJobParameters using new implementation"""
+        # Test the new prepare_job_parameters method
+        switch_handler = cli.SwitchTranspilerHandler(mock_application_context)
+        try:
+            params, wait_for_completion, job_id = switch_handler.prepare_job_parameters(valid_transpile_config)
+        except ImportError:
+            pytest.skip("Switch package not available for parameter mapping test")
+
+        # Verify mapping from TranspileConfig
+        assert params.input_dir == "/Workspace/Users/test/sql_input"
+        assert params.output_dir == "/Workspace/Users/test/notebooks_output"
+        assert params.result_catalog == "test_catalog"
+        assert params.result_schema == "test_schema"
+        assert params.builtin_prompt.value == "snowflake"
+
+        # Verify parameters from Switch config defaults
+        assert params.endpoint_name == "databricks-claude-sonnet-4"
+        assert params.token_count_threshold == 20000
+        assert params.concurrency == 4
+        assert params.comment_lang == "English"
+        assert params.max_fix_attempts == 1
+        assert params.log_level == "INFO"
+
+        # Verify new parameters from defaults
+        assert params.source_format == "sql"
+        assert params.target_type == "notebook"
+        assert params.output_extension is None
+
+        # Verify wait_for_completion and job_id extraction
+        assert not wait_for_completion  # Default from config
+        assert job_id == 12345  # From config fixture
+
+    def test_switch_cli_integration_flow(self, mock_application_context, valid_transpile_config):
+        """Test CLI integration flow with Switch (lightweight, mocked execution)"""
+        # Mock the switch.api components for CLI integration testing
+        with patch("databricks.labs.lakebridge.cli.SwitchJobRunner") as mock_job_runner_class:
+            mock_job_runner = MagicMock()
+            mock_job_runner.run_async.return_value = 987654321  # Mock run ID
+            mock_job_runner_class.return_value = mock_job_runner
+
+            with patch(
+                "databricks.labs.lakebridge.cli.SwitchTranspilerHandler.prepare_job_parameters"
+            ) as mock_prepare_params:
+                mock_params = SwitchJobParameters(
+                    input_dir="/Workspace/Users/test/sql_input",
+                    output_dir="/Workspace/Users/test/notebooks_output",
+                    result_catalog="test_catalog",
+                    result_schema="test_schema",
+                    builtin_prompt="snowflake",
+                )
+                mock_prepare_params.return_value = (mock_params, False, 12345)  # async mode, job_id=12345
+
+                # Execute Switch CLI integration (focus on interface contract)
+                switch_handler = cli.SwitchTranspilerHandler(mock_application_context)
+                result = switch_handler.run_job(valid_transpile_config)
+
+                # Verify CLI interface contract (returns list with single dict)
+                assert isinstance(result, list)
+                assert len(result) == 1
+                result_item = result[0]
+                assert result_item["transpiler"] == "switch"
+                assert result_item["job_id"] == 12345  # From config
+                assert result_item["run_id"] == 987654321
+                assert "run_url" in result_item
+
+                # Verify correct API delegation (CLI integration responsibility)
+                mock_job_runner_class.assert_called_once_with(
+                    mock_application_context.workspace_client, 12345  # job_id from config
+                )
+                mock_job_runner.run_async.assert_called_once_with(mock_params)
+
+                # Verify parameter validation was called
+                mock_prepare_params.assert_called_once_with(valid_transpile_config)
+
+    def test_switch_parameter_integration(self, valid_transpile_config, mock_application_context):
+        """Test new parameter integration (source_format, target_type, output_extension)"""
+        # Test the new parameters in prepare_job_parameters
+        switch_handler = cli.SwitchTranspilerHandler(mock_application_context)
+        try:
+            params, _, _ = switch_handler.prepare_job_parameters(valid_transpile_config)
+        except ImportError:
+            pytest.skip("Switch package not available for parameter integration test")
+
+        # Verify conversion parameters
+        assert hasattr(params, "source_format")
+        assert hasattr(params, "target_type")
+        assert hasattr(params, "output_extension")
+
+        # Verify default values from config
+        assert params.source_format.value == "sql"
+        assert params.target_type.value == "notebook"
+        assert params.output_extension is None
+
+        # Verify request_params parameter
+        assert hasattr(params, "request_params")
+        assert params.request_params is None
+
+    def test_switch_error_handling(self, mock_application_context):
+        """Test CLI error handling for Switch integration issues"""
+        config = TranspileConfig(
+            transpiler_config_path="/fake/switch/config.yml",
+            source_dialect="snowflake",
+            input_source="/test/input",
+            output_folder="/test/output",
+        )
+
+        # Test missing job ID in config
+        with patch(
+            "databricks.labs.lakebridge.cli.SwitchTranspilerHandler.prepare_job_parameters",
+            side_effect=ValueError("Switch job not found"),
+        ):
+            switch_handler = cli.SwitchTranspilerHandler(mock_application_context)
+            with pytest.raises(RuntimeError, match="Switch transpiler failed"):
+                switch_handler.run_job(config)
+
+        # Test Switch job runner failure
+        with patch(
+            "databricks.labs.lakebridge.cli.SwitchTranspilerHandler.prepare_job_parameters",
+            side_effect=RuntimeError("Job runner failed"),
+        ):
+            switch_handler = cli.SwitchTranspilerHandler(mock_application_context)
+            with pytest.raises(RuntimeError, match="Switch transpiler failed"):
+                switch_handler.run_job(config)
+
+    def test_config_job_id_extraction(self, switch_config_path):
+        """Test job ID extraction from Switch config (essential for CLI integration)"""
+        switch_config = TranspilerRepository.user_home().all_transpiler_configs().get("switch")
+        assert switch_config is not None, "Switch config should exist"
+        assert switch_config.custom, "Config should have custom section"
+
+        # job_id can be None if Switch hasn't been deployed yet, or a positive integer if deployed
+        job_id = switch_config.custom.get("job_id")
+        if job_id is not None:
+            assert isinstance(job_id, int), "Job ID should be an integer when present"
+            assert job_id > 0, "Job ID should be positive when present"

--- a/tests/unit/switch/test_install.py
+++ b/tests/unit/switch/test_install.py
@@ -1,0 +1,306 @@
+"""Unit tests for Switch transpiler installation process
+
+Tests Switch installation workflow focusing on workspace deployment and job management.
+Uses lightweight mocking to avoid external dependencies while testing core functionality.
+
+Focus: Workspace operations and configuration management
+Approach: Mock-heavy for workspace operations, fast execution
+Execution time: ~10-15 seconds
+
+Test coverage:
+- test_workspace_deployment:
+    Tests Databricks job creation via SwitchInstaller
+
+- test_config_update:
+    Verifies job information persistence in config.yml
+
+- test_installation_with_cleanup:
+    Tests cleanup of previous installations during new installation
+
+- test_installation_error_handling:
+    Tests error handling during installation process
+"""
+
+import logging
+from unittest.mock import patch, MagicMock
+
+import json
+
+import pytest
+import yaml
+
+from databricks.labs.lakebridge.transpiler.installers import SwitchInstaller
+from databricks.labs.lakebridge.transpiler.repository import TranspilerRepository
+from .conftest import setup_transpiler_repository_mock
+
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def mock_transpiler_repository(tmp_path):
+    """Create a mock TranspilerRepository for testing"""
+    mock_repo = MagicMock(spec=TranspilerRepository)
+    mock_repo.transpilers_path.return_value = tmp_path
+    return mock_repo
+
+
+class TestSwitchInstallationProcess:
+    """Test Switch installation process focusing on workspace operations"""
+
+    def test_workspace_deployment(self, tmp_path, switch_config_data, mock_install_result, mock_workspace_client):
+        """Test workspace deployment creates Databricks job"""
+
+        # Setup Switch config structure
+        switch_dir = tmp_path / "switch" / "lib"
+        switch_dir.mkdir(parents=True)
+        config_path = switch_dir / "config.yml"
+
+        # Create initial config file
+        with config_path.open("w") as f:
+            yaml.dump(switch_config_data, f)
+
+        # Mock TranspilerRepository
+        with patch("databricks.labs.lakebridge.transpiler.repository.TranspilerRepository") as mock_repo_class:
+            mock_repo = MagicMock()
+            setup_transpiler_repository_mock(mock_repo, tmp_path, config_path, switch_config_data)
+            mock_repo_class.return_value = mock_repo
+
+            # Mock SwitchAPIInstaller to return job information
+            with patch(
+                "databricks.labs.lakebridge.transpiler.installers.SwitchAPIInstaller"
+            ) as mock_switch_installer_class:
+                mock_installer = MagicMock()
+                mock_installer.install.return_value = mock_install_result
+                mock_switch_installer_class.return_value = mock_installer
+
+                # Create SwitchInstaller directly
+                switch_installer = SwitchInstaller(mock_repo, mock_workspace_client)
+
+                # Mock the display method to avoid stdout during tests
+                with patch.object(switch_installer, "_display_switch_installation_details") as mock_display:
+                    # Mock Switch version (now imported as SWITCH_VERSION)
+                    with patch("databricks.labs.lakebridge.transpiler.installers.SWITCH_VERSION", "0.1.0"):
+                        # Execute workspace deployment
+                        switch_installer.install()
+
+                        # Verify display method was called with install result
+                        mock_display.assert_called_once_with(mock_install_result)
+
+                # Verify SwitchAPIInstaller was called correctly
+                mock_switch_installer_class.assert_called_once_with(mock_workspace_client)
+                mock_installer.install.assert_called_once_with(
+                    previous_job_id=12345, previous_switch_home="/Workspace/Users/test/.lakebridge-switch"
+                )
+
+                # Verify version.json was created
+                version_json_path = tmp_path / "switch" / "state" / "version.json"
+                assert version_json_path.exists(), "version.json should be created"
+
+                with version_json_path.open("r") as f:
+                    version_data = json.load(f)
+
+                assert version_data["version"] == "v0.1.0", "Version should match Switch version"
+                assert "date" in version_data, "Version data should contain date field"
+
+                logger.info(f"Workspace deployment completed. Job ID: {mock_install_result.job_id}")
+
+    def test_config_update(self, tmp_path, switch_config_data, mock_install_result, mock_workspace_client):
+        """Test config update writes job information to config.yml"""
+
+        # Setup config environment
+        switch_dir = tmp_path / "switch" / "lib"
+        switch_dir.mkdir(parents=True)
+        config_path = switch_dir / "config.yml"
+
+        # Write initial config
+        with config_path.open("w") as f:
+            yaml.dump(switch_config_data, f)
+
+        # Mock TranspilerRepository
+        with patch("databricks.labs.lakebridge.transpiler.repository.TranspilerRepository") as mock_repo_class:
+            mock_repo = MagicMock()
+            setup_transpiler_repository_mock(mock_repo, tmp_path, config_path, switch_config_data)
+            mock_repo_class.return_value = mock_repo
+
+            # Create SwitchInstaller directly
+            switch_installer = SwitchInstaller(mock_repo, mock_workspace_client)
+
+            # Execute config update
+            switch_installer.update_switch_config(mock_install_result)
+
+            # Verify config was updated with job information
+            with config_path.open("r") as f:
+                updated_config = yaml.safe_load(f)
+
+            assert "custom" in updated_config, "Config missing 'custom' section after update"
+            custom = updated_config["custom"]
+
+            assert custom["job_id"] == mock_install_result.job_id
+            assert custom["job_name"] == mock_install_result.job_name
+            assert custom["job_url"] == mock_install_result.job_url
+            assert custom["switch_home"] == mock_install_result.switch_home
+            assert custom["created_by"] == mock_install_result.created_by
+
+            # Verify original config was preserved
+            assert updated_config["remorph"]["name"] == "switch"
+            assert "snowflake" in updated_config["remorph"]["dialects"]
+            assert "options" in updated_config
+
+            logger.info(f"Config updated with job ID {mock_install_result.job_id}")
+
+    def test_installation_with_cleanup(self, tmp_path, mock_install_result, mock_workspace_client):
+        """Test Switch installation with cleanup of previous installation"""
+        # Setup environment with existing Switch installation
+        switch_dir = tmp_path / "switch" / "lib"
+        switch_dir.mkdir(parents=True)
+        config_path = switch_dir / "config.yml"
+
+        # Create config with previous installation info
+        previous_config_data = {
+            "remorph": {
+                "version": 1,
+                "name": "switch",
+                "dialects": ["mysql", "snowflake", "teradata"],
+                "command_line": ["echo", "Switch uses Jobs API, not LSP"],
+            },
+            "options": {"all": []},
+            "custom": {
+                "execution_type": "jobs_api",
+                "job_id": 999888777,
+                "job_name": "old-switch-job",
+                "switch_home": "/Workspace/Users/test/.lakebridge-switch-old",
+            },
+        }
+
+        with config_path.open("w") as f:
+            yaml.dump(previous_config_data, f)
+
+        # Mock TranspilerRepository
+        with patch("databricks.labs.lakebridge.transpiler.repository.TranspilerRepository") as mock_repo_class:
+            mock_repo = MagicMock()
+            setup_transpiler_repository_mock(mock_repo, tmp_path, config_path, previous_config_data)
+            mock_repo_class.return_value = mock_repo
+
+            # Mock workspace deployment
+            with patch(
+                "databricks.labs.lakebridge.transpiler.installers.SwitchAPIInstaller"
+            ) as mock_switch_installer_class:
+                mock_installer = MagicMock()
+                mock_installer.install.return_value = mock_install_result
+                mock_switch_installer_class.return_value = mock_installer
+
+                # Create SwitchInstaller directly
+                switch_installer = SwitchInstaller(mock_repo, mock_workspace_client)
+
+                # Mock the display method to avoid stdout during tests
+                with patch.object(switch_installer, "_display_switch_installation_details") as mock_display:
+                    # Execute installation - should detect and pass previous installation info
+                    switch_installer.install()
+
+                    # Verify display method was called
+                    mock_display.assert_called_once_with(mock_install_result)
+
+                # Verify SwitchAPIInstaller.install was called with previous installation info
+                mock_installer.install.assert_called_once_with(
+                    previous_job_id=999888777, previous_switch_home="/Workspace/Users/test/.lakebridge-switch-old"
+                )
+
+                # Verify config was updated with new job info
+                with config_path.open("r") as f:
+                    updated_config = yaml.safe_load(f)
+
+                assert updated_config["custom"]["job_id"] == mock_install_result.job_id
+                assert updated_config["custom"]["job_name"] == mock_install_result.job_name
+                assert updated_config["custom"]["job_url"] == mock_install_result.job_url
+                assert updated_config["custom"]["switch_home"] == mock_install_result.switch_home
+                assert updated_config["custom"]["created_by"] == mock_install_result.created_by
+
+                logger.info(
+                    f"Previous installation (job_id=999888777) cleaned up and new installation completed (job_id={mock_install_result.job_id})"
+                )
+
+    def test_installation_error_handling(self, tmp_path, switch_config_data, mock_workspace_client):
+        """Test error handling during installation process"""
+        # Setup config environment
+        switch_dir = tmp_path / "switch" / "lib"
+        switch_dir.mkdir(parents=True)
+        config_path = switch_dir / "config.yml"
+
+        # Create initial config file
+        with config_path.open("w") as f:
+            yaml.dump(switch_config_data, f)
+
+        # Mock TranspilerRepository
+        with patch("databricks.labs.lakebridge.transpiler.repository.TranspilerRepository") as mock_repo_class:
+            mock_repo = MagicMock()
+            setup_transpiler_repository_mock(mock_repo, tmp_path, config_path, switch_config_data)
+            mock_repo_class.return_value = mock_repo
+
+            # Create SwitchInstaller directly
+            switch_installer = SwitchInstaller(mock_repo, mock_workspace_client)
+
+            # Mock version state setup (not relevant to error handling tests)
+            with patch.object(switch_installer, "_setup_switch_version_state"):
+                # Test SwitchAPIInstaller.install() failure (implementation: re-raise as RuntimeError)
+                with patch(
+                    "databricks.labs.lakebridge.transpiler.installers.SwitchAPIInstaller"
+                ) as mock_switch_installer_class:
+                    mock_installer = MagicMock()
+                    mock_installer.install.side_effect = Exception("Job creation failed")
+                    mock_switch_installer_class.return_value = mock_installer
+
+                    with pytest.raises(RuntimeError, match="Switch workspace deployment failed"):
+                        switch_installer.install()
+
+                    logger.info("General exception handling verified: RuntimeError raised")
+
+            logger.info("Error handling tests completed successfully")
+
+    def test_config_validation(self, tmp_path):
+        """Test config file validation and error handling through all_transpiler_configs"""
+        with patch(
+            "databricks.labs.lakebridge.transpiler.repository.TranspilerRepository.transpilers_path",
+            return_value=tmp_path,
+        ):
+            switch_dir = tmp_path / "switch" / "lib"
+            switch_dir.mkdir(parents=True)
+            config_path = switch_dir / "config.yml"
+
+            # Test missing config file (implementation: switch not in all_transpiler_configs)
+            all_configs = TranspilerRepository.user_home().all_transpiler_configs()
+            switch_config = all_configs.get("switch")
+            assert switch_config is None, "Config file not found should result in switch not available"
+            logger.info("Missing config file handling verified: None returned")
+
+            # Test invalid config file (implementation: YAML parsing error raises exception)
+            with config_path.open("w") as f:
+                f.write("invalid: yaml: content: [")
+
+            # Invalid YAML will raise an exception during all_transpiler_configs() call
+            with pytest.raises(yaml.scanner.ScannerError):
+                all_configs = TranspilerRepository.user_home().all_transpiler_configs()
+            logger.info("Invalid YAML handling verified: ScannerError raised as expected")
+
+            # Test valid config file (implementation: switch available in all_transpiler_configs)
+            # Use actual Switch config structure (version: 1 is required)
+            valid_config = {
+                "remorph": {
+                    "version": 1,
+                    "name": "switch",
+                    "dialects": ["snowflake"],
+                    "command_line": ["echo", "test"],
+                },
+                "options": {"all": []},
+                "custom": {},
+            }
+            with config_path.open("w") as f:
+                yaml.dump(valid_config, f)
+
+            all_configs = TranspilerRepository.user_home().all_transpiler_configs()
+            switch_config = all_configs.get("switch")
+            assert switch_config is not None, "Valid config should be available in all_transpiler_configs"
+            assert switch_config.name == "switch", "Config should have correct transpiler name"
+            logger.info("Valid config handling verified: LSPConfig object returned")
+
+            logger.info("Config validation tests completed successfully")

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -1393,8 +1393,8 @@ def test_installer_upgrade_installed_transpilers(
     )
 
     class MockTranspilerInstaller(TranspilerInstaller):
-        def __init__(self, repository: TranspilerRepository, name: str) -> None:
-            super().__init__(repository)
+        def __init__(self, repository: TranspilerRepository, workspace_client: WorkspaceClient, name: str) -> None:
+            super().__init__(repository, workspace_client)
             self._name = name
             self.installed = False
 
@@ -1409,12 +1409,14 @@ def test_installer_upgrade_installed_transpilers(
             self.installed = True
             return True
 
-        def mock_factory(self, repository: TranspilerRepository) -> TranspilerInstaller:
+        def mock_factory(
+            self, repository: TranspilerRepository, _workspace_client: WorkspaceClient
+        ) -> TranspilerInstaller:
             assert repository is self._transpiler_repository
             return self
 
-    bar_installer = MockTranspilerInstaller(mock_repository, "bar")
-    baz_installer = MockTranspilerInstaller(mock_repository, "baz")
+    bar_installer = MockTranspilerInstaller(mock_repository, ctx.workspace_client, "bar")
+    baz_installer = MockTranspilerInstaller(mock_repository, ctx.workspace_client, "baz")
 
     installer = ws_installer(
         ctx.workspace_client,
@@ -1478,8 +1480,8 @@ def test_installer_upgrade_configure_if_changed(
     )
 
     class MockTranspilerInstaller(TranspilerInstaller):
-        def __init__(self, repository: TranspilerRepository) -> None:
-            super().__init__(repository)
+        def __init__(self, repository: TranspilerRepository, workspace_client: WorkspaceClient) -> None:
+            super().__init__(repository, workspace_client)
             self.installed = False
 
         def can_install(self, artifact: Path) -> bool:


### PR DESCRIPTION
## Changes 
This PR integrates **Switch**, a Lakebridge transpiler plugin that uses Large Language Models (LLMs) to convert SQL and other source formats into Databricks notebooks or generic files. Switch leverages Mosaic AI Model Serving to understand code intent and semantics, generating equivalent Python notebooks with Spark SQL or other target formats.

### What does this PR do?
Integrates Switch as a pluggable transpiler into Lakebridge using existing command interfaces. No changes to existing Lakebridge commands - users can install and run Switch through the same `databricks labs lakebridge` commands.

#### What's added
1. **Command integration**: Switch installation, transpilation, and uninstallation through existing Lakebridge commands
2. **Test coverage**: Unit tests and E2E tests for Switch functionality
3. **Documentation**: Comprehensive Switch documentation and Switch references added to existing Lakebridge docs

### Relevant implementation details
#### 1. Command Integration
Added Switch support to `install-transpile`, `transpile`, and `uninstall` commands without changing existing command interfaces:

- **`install-transpile`**: Added `SwitchInstaller` class for workspace notebook deployment, job creation, and config setup in [`src/databricks/labs/lakebridge/transpiler/installers.py`](https://github.com/databrickslabs/lakebridge/blob/switch-integration/src/databricks/labs/lakebridge/transpiler/installers.py#L534)
- **`transpile`**: Added `SwitchTranspilerHandler` class for Switch routing (based on `--transpiler-config-path`), CLI-to-job parameter mapping, and job execution in [`src/databricks/labs/lakebridge/cli.py`](https://github.com/databrickslabs/lakebridge/blob/switch-integration/src/databricks/labs/lakebridge/cli.py#L137)
- **`uninstall`**: Enhanced existing command with Switch cleanup (job and notebook removal from workspace, local config deletion) in [`src/databricks/labs/lakebridge/deployment/installation.py`](https://github.com/databrickslabs/lakebridge/blob/switch-integration/src/databricks/labs/lakebridge/deployment/installation.py#L132)

#### 2. Test Coverage
Added comprehensive unit and E2E tests for Switch functionality:

- **Unit Tests** (mock-based, CI/CD automated execution):
  - CLI integration and transpiler routing tests ([`tests/unit/switch/test_cli.py`](https://github.com/databrickslabs/lakebridge/tree/switch-integration/tests/unit/switch/test_cli.py))
  - Installation and configuration management tests ([`tests/unit/switch/test_install.py`](https://github.com/databrickslabs/lakebridge/tree/switch-integration/tests/unit/switch/test_install.py))
  - Test fixtures and mocking setup ([`tests/unit/switch/conftest.py`](https://github.com/databrickslabs/lakebridge/tree/switch-integration/tests/unit/switch/conftest.py))
- **Integration/E2E Tests** (real workspace, manual execution):
  - End-to-end workflow validation with Databricks workspace ([`tests/integration/switch/test_e2e.py`](https://github.com/databrickslabs/lakebridge/tree/switch-integration/tests/integration/switch/test_e2e.py))
  - Executed when `LAKEBRIDGE_SWITCH_E2E=true` environment variable is set, otherwise skipped

#### 3. Documentation
- Created comprehensive Switch documentation covering installation, usage, and configuration:
  - [`docs/lakebridge/docs/transpile/pluggable_transpilers/switch.mdx`](https://github.com/databrickslabs/lakebridge/tree/switch-integration/docs/lakebridge/docs/transpile/pluggable_transpilers/switch.mdx)
- Added Switch references to existing Lakebridge documentation:
  - [`docs/lakebridge/docs/overview.mdx`](https://github.com/databrickslabs/lakebridge/tree/switch-integration/docs/lakebridge/docs/overview.mdx)
  - [`docs/lakebridge/docs/transpile/overview.mdx`](https://github.com/databrickslabs/lakebridge/tree/switch-integration/docs/lakebridge/docs/transpile/overview.mdx)
  - [`docs/lakebridge/docs/transpile/pluggable_transpilers/index.mdx`](https://github.com/databrickslabs/lakebridge/tree/switch-integration/docs/lakebridge/docs/transpile/pluggable_transpilers/index.mdx)

### Caveats/things to watch out for when reviewing:

#### Switch Usage
As documented in [`docs/lakebridge/docs/transpile/pluggable_transpilers/switch.mdx`](https://github.com/databrickslabs/lakebridge/tree/switch-integration/docs/lakebridge/docs/transpile/pluggable_transpilers/switch.mdx), Switch installation uses the `install-transpile` command. For conversion, the `transpile` command is used - specifying the Switch config file with `--transpiler-config-path` tells Lakebridge to use Switch as the transpiler.

#### Switch Dependency Addition to pyproject.toml
Added Switch PyPI package (https://pypi.org/project/databricks-switch-plugin/) as a dependency, starting from version 0.1.0 following Databricks Labs conventions. Additionally, added `python-dotenv` to `[tool.hatch.envs.default]` dependencies to simplify testing.

**Why add Switch PyPI as a dependency?**
Both `SwitchInstaller` (during installation) and `SwitchTranspilerHandler` (during transpilation execution) require direct access to Switch APIs. Using WheelInstaller would create an isolated virtual environment that would be inaccessible from the execution context of these components.

#### WorkspaceClient Addition to TranspilerInstaller
Added `workspace_client: WorkspaceClient` argument to the `TranspilerInstaller` class `__init__` method. This is required for Switch installation to upload notebooks and create jobs in the Databricks workspace.

### Functionality

- [x] added relevant user documentation
- [x] enhanced `install-transpile`, `transpile`, and `uninstall` commands with Switch support

### Tests

- [x] manually tested
- [x] added unit tests
- [x] added integration tests
