### PR TITLE
Add Switch transpiler installation infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 __pycache__
 dist
 .idea
+.vscode/
 /htmlcov/
 *.iml
 target/
@@ -22,3 +23,4 @@ remorph_transpile/
 /linter/src/main/antlr4/library/gen/
 .databricks-login.json
 .mypy_cache
+.env

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
   "SQLAlchemy~=2.0.40",
   "pygls~=2.0.0a2",
   "duckdb~=1.2.2",
+  "databricks-switch-plugin>=0.1.0",
 ]
 
 [project.urls]
@@ -84,7 +85,8 @@ dependencies = [
   "pandas-stubs~=2.3.0.250703",
   "cattrs>=25.2.0",
   "click<8.3.0", # https://github.com/pallets/click/issues/3065 for ruff
-  "faker"
+  "faker",
+  "python-dotenv"
 ]
 
 [project.entry-points.databricks]

--- a/src/databricks/labs/lakebridge/install.py
+++ b/src/databricks/labs/lakebridge/install.py
@@ -28,6 +28,7 @@ from databricks.labs.lakebridge.reconcile.constants import ReconReportType, Reco
 from databricks.labs.lakebridge.transpiler.installers import (
     BladebridgeInstaller,
     MorpheusInstaller,
+    SwitchInstaller,
     TranspilerInstaller,
 )
 from databricks.labs.lakebridge.transpiler.repository import TranspilerRepository
@@ -51,9 +52,10 @@ class WorkspaceInstaller:
         *,
         is_interactive: bool = True,
         transpiler_repository: TranspilerRepository = TranspilerRepository.user_home(),
-        transpiler_installers: Sequence[Callable[[TranspilerRepository], TranspilerInstaller]] = (
+        transpiler_installers: Sequence[Callable[[TranspilerRepository, WorkspaceClient], TranspilerInstaller]] = (
             BladebridgeInstaller,
             MorpheusInstaller,
+            SwitchInstaller,
         ),
     ):
         self._ws = ws
@@ -77,7 +79,9 @@ class WorkspaceInstaller:
 
     @property
     def _transpiler_installers(self) -> Set[TranspilerInstaller]:
-        return frozenset(factory(self._transpiler_repository) for factory in self._transpiler_installer_factories)
+        return frozenset(
+            factory(self._transpiler_repository, self._ws) for factory in self._transpiler_installer_factories
+        )
 
     def run(
         self,

--- a/tests/unit/switch/conftest.py
+++ b/tests/unit/switch/conftest.py
@@ -1,0 +1,204 @@
+"""Shared test fixtures and configuration for Switch unit tests"""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+import yaml
+
+
+@pytest.fixture
+def switch_config_data():
+    """Shared Switch configuration data matching actual config.yml"""
+    return {
+        "remorph": {
+            "version": 1,
+            "name": "switch",
+            "command_line": ["echo", "Switch uses Jobs API, not LSP"],
+            "dialects": [
+                "mssql",
+                "mysql",
+                "netezza",
+                "oracle",
+                "postgresql",
+                "redshift",
+                "snowflake",
+                "synapse",
+                "teradata",
+                "python",
+                "scala",
+                "airflow",
+            ],
+        },
+        "options": {
+            "all": [
+                {
+                    "flag": "source_format",
+                    "method": "CHOICE",
+                    "prompt": "Source file format",
+                    "choices": ["sql", "generic"],
+                    "default": "sql",
+                },
+                {
+                    "flag": "target_type",
+                    "method": "CHOICE",
+                    "prompt": "Target output type",
+                    "choices": ["notebook", "file"],
+                    "default": "notebook",
+                },
+                {
+                    "flag": "output_extension",
+                    "method": "QUESTION",
+                    "prompt": "Output file extension (for file target type) - press <enter> for none",
+                    "default": "<none>",
+                },
+                {
+                    "flag": "endpoint_name",
+                    "method": "QUESTION",
+                    "prompt": "Model endpoint name",
+                    "default": "databricks-claude-sonnet-4",
+                },
+                {"flag": "concurrency", "method": "QUESTION", "prompt": "Concurrency level", "default": 4},
+                {"flag": "max_fix_attempts", "method": "QUESTION", "prompt": "Maximum fix attempts", "default": 1},
+                {
+                    "flag": "log_level",
+                    "method": "CHOICE",
+                    "prompt": "Log level",
+                    "choices": ["DEBUG", "INFO", "WARNING", "ERROR"],
+                    "default": "INFO",
+                },
+                {
+                    "flag": "token_count_threshold",
+                    "method": "QUESTION",
+                    "prompt": "Token count threshold",
+                    "default": 20000,
+                },
+                {
+                    "flag": "comment_lang",
+                    "method": "CHOICE",
+                    "prompt": "Comment language",
+                    "choices": [
+                        "English",
+                        "Japanese",
+                        "Chinese",
+                        "French",
+                        "German",
+                        "Italian",
+                        "Korean",
+                        "Portuguese",
+                        "Spanish",
+                    ],
+                    "default": "English",
+                },
+                {
+                    "flag": "conversion_prompt_yaml",
+                    "method": "QUESTION",
+                    "prompt": "Custom conversion prompt YAML file path - press <enter> for default",
+                    "default": "<none>",
+                },
+                {
+                    "flag": "sql_output_dir",
+                    "method": "QUESTION",
+                    "prompt": "SQL output directory - press <enter> for none",
+                    "default": "<none>",
+                },
+                {
+                    "flag": "request_params",
+                    "method": "QUESTION",
+                    "prompt": "Additional request parameters (JSON) - press <enter> for none",
+                    "default": "<none>",
+                },
+                {
+                    "flag": "wait_for_completion",
+                    "method": "CHOICE",
+                    "prompt": "Wait for job completion?",
+                    "choices": ["true", "false"],
+                    "default": "false",
+                },
+            ]
+        },
+        "custom": {
+            "execution_type": "jobs_api",
+            "job_id": 12345,
+            "job_name": "lakebridge-switch",
+            "job_url": "https://test.databricks.com/jobs/12345",
+            "switch_home": "/Workspace/Users/test/.lakebridge-switch",
+            "created_by": "test@databricks.com",
+        },
+    }
+
+
+@pytest.fixture
+def switch_config_path(switch_config_data):
+    """Create a temporary Switch config file for testing"""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+
+        # Create Switch config structure
+        switch_dir = temp_path / "switch" / "lib"
+        switch_dir.mkdir(parents=True)
+
+        config_path = switch_dir / "config.yml"
+        with config_path.open("w") as f:
+            yaml.dump(switch_config_data, f)
+
+        # Patch TranspilerRepository to use temp directory
+        with patch(
+            "databricks.labs.lakebridge.transpiler.repository.TranspilerRepository.transpilers_path",
+            return_value=temp_path,
+        ):
+            with patch(
+                "databricks.labs.lakebridge.transpiler.repository.TranspilerRepository.all_transpiler_names",
+                return_value={"switch"},
+            ):
+                # Create mock LSPConfig object
+                mock_switch_config = MagicMock()
+                mock_switch_config.custom = switch_config_data.get("custom", {})
+                mock_switch_config.options = switch_config_data.get("options", {})
+                with patch(
+                    "databricks.labs.lakebridge.transpiler.repository.TranspilerRepository.all_transpiler_configs",
+                    return_value={"switch": mock_switch_config},
+                ):
+                    yield config_path
+
+
+@pytest.fixture
+def mock_application_context():
+    """Create a mock ApplicationContext for testing"""
+    mock_ctx = MagicMock()
+    mock_ctx.workspace_client = MagicMock()
+    mock_ctx.workspace_client.config.host = "https://test.databricks.com"
+    return mock_ctx
+
+
+@pytest.fixture
+def mock_workspace_client():
+    """Create a mock WorkspaceClient for testing"""
+    mock_ws = MagicMock()
+    mock_ws.config.host = "https://test.databricks.com"
+    return mock_ws
+
+
+@pytest.fixture
+def mock_install_result():
+    """Mock SwitchInstaller.install() result"""
+    result = MagicMock()
+    result.job_id = 123456789
+    result.job_name = "lakebridge-switch"
+    result.job_url = "https://test.databricks.com/jobs/123456789"
+    result.switch_home = "/Workspace/Users/test/.lakebridge-switch"
+    result.created_by = "test@databricks.com"
+    return result
+
+
+def setup_transpiler_repository_mock(mock_repo, tmp_path, config_path, config_data):
+    """Setup common TranspilerRepository mock configuration"""
+    mock_repo.transpilers_path.return_value = tmp_path
+    mock_repo.transpiler_config_path.return_value = config_path
+
+    mock_switch_config = MagicMock()
+    mock_switch_config.custom = config_data.get("custom", {})
+    mock_repo.all_transpiler_configs.return_value = {"switch": mock_switch_config}
+
+    return mock_repo

--- a/tests/unit/switch/test_install.py
+++ b/tests/unit/switch/test_install.py
@@ -1,0 +1,306 @@
+"""Unit tests for Switch transpiler installation process
+
+Tests Switch installation workflow focusing on workspace deployment and job management.
+Uses lightweight mocking to avoid external dependencies while testing core functionality.
+
+Focus: Workspace operations and configuration management
+Approach: Mock-heavy for workspace operations, fast execution
+Execution time: ~10-15 seconds
+
+Test coverage:
+- test_workspace_deployment:
+    Tests Databricks job creation via SwitchInstaller
+
+- test_config_update:
+    Verifies job information persistence in config.yml
+
+- test_installation_with_cleanup:
+    Tests cleanup of previous installations during new installation
+
+- test_installation_error_handling:
+    Tests error handling during installation process
+"""
+
+import logging
+from unittest.mock import patch, MagicMock
+
+import json
+
+import pytest
+import yaml
+
+from databricks.labs.lakebridge.transpiler.installers import SwitchInstaller
+from databricks.labs.lakebridge.transpiler.repository import TranspilerRepository
+from .conftest import setup_transpiler_repository_mock
+
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def mock_transpiler_repository(tmp_path):
+    """Create a mock TranspilerRepository for testing"""
+    mock_repo = MagicMock(spec=TranspilerRepository)
+    mock_repo.transpilers_path.return_value = tmp_path
+    return mock_repo
+
+
+class TestSwitchInstallationProcess:
+    """Test Switch installation process focusing on workspace operations"""
+
+    def test_workspace_deployment(self, tmp_path, switch_config_data, mock_install_result, mock_workspace_client):
+        """Test workspace deployment creates Databricks job"""
+
+        # Setup Switch config structure
+        switch_dir = tmp_path / "switch" / "lib"
+        switch_dir.mkdir(parents=True)
+        config_path = switch_dir / "config.yml"
+
+        # Create initial config file
+        with config_path.open("w") as f:
+            yaml.dump(switch_config_data, f)
+
+        # Mock TranspilerRepository
+        with patch("databricks.labs.lakebridge.transpiler.repository.TranspilerRepository") as mock_repo_class:
+            mock_repo = MagicMock()
+            setup_transpiler_repository_mock(mock_repo, tmp_path, config_path, switch_config_data)
+            mock_repo_class.return_value = mock_repo
+
+            # Mock SwitchAPIInstaller to return job information
+            with patch(
+                "databricks.labs.lakebridge.transpiler.installers.SwitchAPIInstaller"
+            ) as mock_switch_installer_class:
+                mock_installer = MagicMock()
+                mock_installer.install.return_value = mock_install_result
+                mock_switch_installer_class.return_value = mock_installer
+
+                # Create SwitchInstaller directly
+                switch_installer = SwitchInstaller(mock_repo, mock_workspace_client)
+
+                # Mock the display method to avoid stdout during tests
+                with patch.object(switch_installer, "_display_switch_installation_details") as mock_display:
+                    # Mock Switch version (now imported as SWITCH_VERSION)
+                    with patch("databricks.labs.lakebridge.transpiler.installers.SWITCH_VERSION", "0.1.0"):
+                        # Execute workspace deployment
+                        switch_installer.install()
+
+                        # Verify display method was called with install result
+                        mock_display.assert_called_once_with(mock_install_result)
+
+                # Verify SwitchAPIInstaller was called correctly
+                mock_switch_installer_class.assert_called_once_with(mock_workspace_client)
+                mock_installer.install.assert_called_once_with(
+                    previous_job_id=12345, previous_switch_home="/Workspace/Users/test/.lakebridge-switch"
+                )
+
+                # Verify version.json was created
+                version_json_path = tmp_path / "switch" / "state" / "version.json"
+                assert version_json_path.exists(), "version.json should be created"
+
+                with version_json_path.open("r") as f:
+                    version_data = json.load(f)
+
+                assert version_data["version"] == "v0.1.0", "Version should match Switch version"
+                assert "date" in version_data, "Version data should contain date field"
+
+                logger.info(f"Workspace deployment completed. Job ID: {mock_install_result.job_id}")
+
+    def test_config_update(self, tmp_path, switch_config_data, mock_install_result, mock_workspace_client):
+        """Test config update writes job information to config.yml"""
+
+        # Setup config environment
+        switch_dir = tmp_path / "switch" / "lib"
+        switch_dir.mkdir(parents=True)
+        config_path = switch_dir / "config.yml"
+
+        # Write initial config
+        with config_path.open("w") as f:
+            yaml.dump(switch_config_data, f)
+
+        # Mock TranspilerRepository
+        with patch("databricks.labs.lakebridge.transpiler.repository.TranspilerRepository") as mock_repo_class:
+            mock_repo = MagicMock()
+            setup_transpiler_repository_mock(mock_repo, tmp_path, config_path, switch_config_data)
+            mock_repo_class.return_value = mock_repo
+
+            # Create SwitchInstaller directly
+            switch_installer = SwitchInstaller(mock_repo, mock_workspace_client)
+
+            # Execute config update
+            switch_installer.update_switch_config(mock_install_result)
+
+            # Verify config was updated with job information
+            with config_path.open("r") as f:
+                updated_config = yaml.safe_load(f)
+
+            assert "custom" in updated_config, "Config missing 'custom' section after update"
+            custom = updated_config["custom"]
+
+            assert custom["job_id"] == mock_install_result.job_id
+            assert custom["job_name"] == mock_install_result.job_name
+            assert custom["job_url"] == mock_install_result.job_url
+            assert custom["switch_home"] == mock_install_result.switch_home
+            assert custom["created_by"] == mock_install_result.created_by
+
+            # Verify original config was preserved
+            assert updated_config["remorph"]["name"] == "switch"
+            assert "snowflake" in updated_config["remorph"]["dialects"]
+            assert "options" in updated_config
+
+            logger.info(f"Config updated with job ID {mock_install_result.job_id}")
+
+    def test_installation_with_cleanup(self, tmp_path, mock_install_result, mock_workspace_client):
+        """Test Switch installation with cleanup of previous installation"""
+        # Setup environment with existing Switch installation
+        switch_dir = tmp_path / "switch" / "lib"
+        switch_dir.mkdir(parents=True)
+        config_path = switch_dir / "config.yml"
+
+        # Create config with previous installation info
+        previous_config_data = {
+            "remorph": {
+                "version": 1,
+                "name": "switch",
+                "dialects": ["mysql", "snowflake", "teradata"],
+                "command_line": ["echo", "Switch uses Jobs API, not LSP"],
+            },
+            "options": {"all": []},
+            "custom": {
+                "execution_type": "jobs_api",
+                "job_id": 999888777,
+                "job_name": "old-switch-job",
+                "switch_home": "/Workspace/Users/test/.lakebridge-switch-old",
+            },
+        }
+
+        with config_path.open("w") as f:
+            yaml.dump(previous_config_data, f)
+
+        # Mock TranspilerRepository
+        with patch("databricks.labs.lakebridge.transpiler.repository.TranspilerRepository") as mock_repo_class:
+            mock_repo = MagicMock()
+            setup_transpiler_repository_mock(mock_repo, tmp_path, config_path, previous_config_data)
+            mock_repo_class.return_value = mock_repo
+
+            # Mock workspace deployment
+            with patch(
+                "databricks.labs.lakebridge.transpiler.installers.SwitchAPIInstaller"
+            ) as mock_switch_installer_class:
+                mock_installer = MagicMock()
+                mock_installer.install.return_value = mock_install_result
+                mock_switch_installer_class.return_value = mock_installer
+
+                # Create SwitchInstaller directly
+                switch_installer = SwitchInstaller(mock_repo, mock_workspace_client)
+
+                # Mock the display method to avoid stdout during tests
+                with patch.object(switch_installer, "_display_switch_installation_details") as mock_display:
+                    # Execute installation - should detect and pass previous installation info
+                    switch_installer.install()
+
+                    # Verify display method was called
+                    mock_display.assert_called_once_with(mock_install_result)
+
+                # Verify SwitchAPIInstaller.install was called with previous installation info
+                mock_installer.install.assert_called_once_with(
+                    previous_job_id=999888777, previous_switch_home="/Workspace/Users/test/.lakebridge-switch-old"
+                )
+
+                # Verify config was updated with new job info
+                with config_path.open("r") as f:
+                    updated_config = yaml.safe_load(f)
+
+                assert updated_config["custom"]["job_id"] == mock_install_result.job_id
+                assert updated_config["custom"]["job_name"] == mock_install_result.job_name
+                assert updated_config["custom"]["job_url"] == mock_install_result.job_url
+                assert updated_config["custom"]["switch_home"] == mock_install_result.switch_home
+                assert updated_config["custom"]["created_by"] == mock_install_result.created_by
+
+                logger.info(
+                    f"Previous installation (job_id=999888777) cleaned up and new installation completed (job_id={mock_install_result.job_id})"
+                )
+
+    def test_installation_error_handling(self, tmp_path, switch_config_data, mock_workspace_client):
+        """Test error handling during installation process"""
+        # Setup config environment
+        switch_dir = tmp_path / "switch" / "lib"
+        switch_dir.mkdir(parents=True)
+        config_path = switch_dir / "config.yml"
+
+        # Create initial config file
+        with config_path.open("w") as f:
+            yaml.dump(switch_config_data, f)
+
+        # Mock TranspilerRepository
+        with patch("databricks.labs.lakebridge.transpiler.repository.TranspilerRepository") as mock_repo_class:
+            mock_repo = MagicMock()
+            setup_transpiler_repository_mock(mock_repo, tmp_path, config_path, switch_config_data)
+            mock_repo_class.return_value = mock_repo
+
+            # Create SwitchInstaller directly
+            switch_installer = SwitchInstaller(mock_repo, mock_workspace_client)
+
+            # Mock version state setup (not relevant to error handling tests)
+            with patch.object(switch_installer, "_setup_switch_version_state"):
+                # Test SwitchAPIInstaller.install() failure (implementation: re-raise as RuntimeError)
+                with patch(
+                    "databricks.labs.lakebridge.transpiler.installers.SwitchAPIInstaller"
+                ) as mock_switch_installer_class:
+                    mock_installer = MagicMock()
+                    mock_installer.install.side_effect = Exception("Job creation failed")
+                    mock_switch_installer_class.return_value = mock_installer
+
+                    with pytest.raises(RuntimeError, match="Switch workspace deployment failed"):
+                        switch_installer.install()
+
+                    logger.info("General exception handling verified: RuntimeError raised")
+
+            logger.info("Error handling tests completed successfully")
+
+    def test_config_validation(self, tmp_path):
+        """Test config file validation and error handling through all_transpiler_configs"""
+        with patch(
+            "databricks.labs.lakebridge.transpiler.repository.TranspilerRepository.transpilers_path",
+            return_value=tmp_path,
+        ):
+            switch_dir = tmp_path / "switch" / "lib"
+            switch_dir.mkdir(parents=True)
+            config_path = switch_dir / "config.yml"
+
+            # Test missing config file (implementation: switch not in all_transpiler_configs)
+            all_configs = TranspilerRepository.user_home().all_transpiler_configs()
+            switch_config = all_configs.get("switch")
+            assert switch_config is None, "Config file not found should result in switch not available"
+            logger.info("Missing config file handling verified: None returned")
+
+            # Test invalid config file (implementation: YAML parsing error raises exception)
+            with config_path.open("w") as f:
+                f.write("invalid: yaml: content: [")
+
+            # Invalid YAML will raise an exception during all_transpiler_configs() call
+            with pytest.raises(yaml.scanner.ScannerError):
+                all_configs = TranspilerRepository.user_home().all_transpiler_configs()
+            logger.info("Invalid YAML handling verified: ScannerError raised as expected")
+
+            # Test valid config file (implementation: switch available in all_transpiler_configs)
+            # Use actual Switch config structure (version: 1 is required)
+            valid_config = {
+                "remorph": {
+                    "version": 1,
+                    "name": "switch",
+                    "dialects": ["snowflake"],
+                    "command_line": ["echo", "test"],
+                },
+                "options": {"all": []},
+                "custom": {},
+            }
+            with config_path.open("w") as f:
+                yaml.dump(valid_config, f)
+
+            all_configs = TranspilerRepository.user_home().all_transpiler_configs()
+            switch_config = all_configs.get("switch")
+            assert switch_config is not None, "Valid config should be available in all_transpiler_configs"
+            assert switch_config.name == "switch", "Config should have correct transpiler name"
+            logger.info("Valid config handling verified: LSPConfig object returned")
+
+            logger.info("Config validation tests completed successfully")

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -1393,8 +1393,8 @@ def test_installer_upgrade_installed_transpilers(
     )
 
     class MockTranspilerInstaller(TranspilerInstaller):
-        def __init__(self, repository: TranspilerRepository, name: str) -> None:
-            super().__init__(repository)
+        def __init__(self, repository: TranspilerRepository, workspace_client: WorkspaceClient, name: str) -> None:
+            super().__init__(repository, workspace_client)
             self._name = name
             self.installed = False
 
@@ -1409,12 +1409,14 @@ def test_installer_upgrade_installed_transpilers(
             self.installed = True
             return True
 
-        def mock_factory(self, repository: TranspilerRepository) -> TranspilerInstaller:
+        def mock_factory(
+            self, repository: TranspilerRepository, _workspace_client: WorkspaceClient
+        ) -> TranspilerInstaller:
             assert repository is self._transpiler_repository
             return self
 
-    bar_installer = MockTranspilerInstaller(mock_repository, "bar")
-    baz_installer = MockTranspilerInstaller(mock_repository, "baz")
+    bar_installer = MockTranspilerInstaller(mock_repository, ctx.workspace_client, "bar")
+    baz_installer = MockTranspilerInstaller(mock_repository, ctx.workspace_client, "baz")
 
     installer = ws_installer(
         ctx.workspace_client,
@@ -1478,8 +1480,8 @@ def test_installer_upgrade_configure_if_changed(
     )
 
     class MockTranspilerInstaller(TranspilerInstaller):
-        def __init__(self, repository: TranspilerRepository) -> None:
-            super().__init__(repository)
+        def __init__(self, repository: TranspilerRepository, workspace_client: WorkspaceClient) -> None:
+            super().__init__(repository, workspace_client)
             self.installed = False
 
         def can_install(self, artifact: Path) -> bool:


### PR DESCRIPTION
## Changes
This PR adds foundational infrastructure for Switch, an LLM-powered transpiler. Includes package integration, installer class, and workspace deployment capabilities.

### What does this PR do?
Adds installation infrastructure for Switch transpiler integration into Lakebridge ecosystem.

### Relevant implementation details
**Package Integration**:
- Add `databricks-switch-plugin>=0.1.0` to pyproject.toml (temporary package name)
- Add `python-dotenv` for testing support

**Installation Infrastructure**:
- `SwitchInstaller` class with workspace deployment and job creation
- Updated `TranspilerInstaller` base class to require `WorkspaceClient` parameter
- Added Switch to workspace installer factory list
- Switch cleanup integration in uninstall process

**Testing**:
- Unit tests for Switch installation functionality
- Updated existing tests for `WorkspaceClient` parameter change

### Caveats/things to watch out for when reviewing:
- Package dependency is temporary - will be updated with final Labs PyPI package name
- This is foundational PR that enables Switch imports - must be merged before switch-transpilation #2049 

### Linked issues
Resolves #2046

### Functionality
- [ ] added relevant user documentation
- [ ] added new CLI command
- [x] modified existing command: `databricks labs lakebridge install-transpile` (adds Switch installation support)
- [x] modified existing command: `databricks labs uninstall lakebridge` (adds Switch uninstall support)

### Tests
- [x] manually tested
- [x] added unit tests
- [ ] added integration tests