### PR TITLE
Ensure consistent ordering when describing the installed transpilers

### DIFF
--- a/src/databricks/labs/lakebridge/transpiler/describe.py
+++ b/src/databricks/labs/lakebridge/transpiler/describe.py
@@ -53,7 +53,7 @@ class TranspilersDescription:
         all_dialects = cast(JsonList, sorted(list(transpiler_repository.all_dialects())))
         return {
             "installed-transpilers": [
-                self.transpiler_as_json(info) for product_name, info in installed_transpilers.items()
+                self.transpiler_as_json(info) for product_name, info in sorted(installed_transpilers.items())
             ],
             "available-dialects": all_dialects,
         }

--- a/tests/integration/transpile/test_describe.py
+++ b/tests/integration/transpile/test_describe.py
@@ -37,18 +37,6 @@ def test_describe_installed_transpilers(transpiler_repository: TranspilerReposit
         ],
         "installed-transpilers": [
             {
-                "name": "Morpheus",
-                "config-path": str(transpiler_repository.transpilers_path() / "morpheus" / "lib" / "config.yml"),
-                "versions": {
-                    "installed": "0.4.0",
-                    "latest": None,
-                },
-                "supported-dialects": {
-                    "snowflake": {"options": []},
-                    "tsql": {"options": []},
-                },
-            },
-            {
                 "name": "Bladebridge",
                 "config-path": str(transpiler_repository.transpilers_path() / "bladebridge" / "lib" / "config.yml"),
                 "versions": {
@@ -68,6 +56,18 @@ def test_describe_installed_transpilers(transpiler_repository: TranspilerReposit
                     "snowflake": {"options": [bb_overrides]},
                     "synapse": {"options": [bb_overrides]},
                     "teradata": {"options": [bb_overrides]},
+                },
+            },
+            {
+                "name": "Morpheus",
+                "config-path": str(transpiler_repository.transpilers_path() / "morpheus" / "lib" / "config.yml"),
+                "versions": {
+                    "installed": "0.4.0",
+                    "latest": None,
+                },
+                "supported-dialects": {
+                    "snowflake": {"options": []},
+                    "tsql": {"options": []},
                 },
             },
         ],

--- a/tests/unit/transpiler/test_describe.py
+++ b/tests/unit/transpiler/test_describe.py
@@ -119,17 +119,6 @@ def test_transpiler_repository_as_json() -> None:
         "available-dialects": ["bar", "foo"],
         "installed-transpilers": [
             {
-                "name": "Foo",
-                "config-path": "/path/to/foo/config.yml",
-                "versions": {
-                    "installed": "1.0.0",
-                    "latest": None,
-                },
-                "supported-dialects": {
-                    "foo": {"options": []},
-                },
-            },
-            {
                 "name": "Bar",
                 "config-path": "/path/to/bar/config.yml",
                 "versions": {
@@ -138,6 +127,17 @@ def test_transpiler_repository_as_json() -> None:
                 },
                 "supported-dialects": {
                     "bar": {"options": [{"flag": "an_option", "method": "CONFIRM", "prompt": "Have you any wool?"}]},
+                },
+            },
+            {
+                "name": "Foo",
+                "config-path": "/path/to/foo/config.yml",
+                "versions": {
+                    "installed": "1.0.0",
+                    "latest": None,
+                },
+                "supported-dialects": {
+                    "foo": {"options": []},
                 },
             },
         ],


### PR DESCRIPTION
## Changes

This PR updates output when describing the installed transpilers to ensure the ordering is consistent. (This in turns resolves a flaky integration test.)

### Relevant implementation details

Prior to this PR the order of the transpilers was simply the order that were returned when enumerating the directory entries.

### Functionality

- modified existing command: `databricks labs lakebridge describe-transpile`

### Tests

- manually tested
- updated unit tests
- updated integration tests

Output when running it manually:
```
% databricks labs lakebridge describe-transpile         
Transpiler   Installed Version  Plugin Configuration
==========   =================  ====================
Bladebridge  0.1.16             /Users/andrew.snare/.databricks/labs/remorph-transpilers/bladebridge/lib/config.yml
Morpheus     0.6.7              /Users/andrew.snare/.databricks/labs/remorph-transpilers/databricks-morph-plugin/lib/config.yml

Supported Source Dialects
=========================
 - datastage
 - informatica (desktop edition)
 - informatica cloud
 - mssql
 - netezza
 - oracle
 - snowflake
 - synapse
 - teradata
```