### PR TITLE
Switch from `urllib` to `requests` for making HTTP calls to PyPI and Maven Central

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
   "SQLAlchemy~=2.0.40",
   "pygls~=2.0.0a2",
   "duckdb~=1.2.2",
+  "requests>=2.28.1,<3"  # Matches databricks-sdk (and 'types-requests' below), to avoid conflicts.
 ]
 
 [project.urls]
@@ -74,6 +75,7 @@ dependencies = [
   "black~=25.1.0",
   "ruff~=0.11.6",
   "databricks-connect==15.1",
+  "types-requests>=2.28.1,<3",  # Matches the 'requests' above.
   "types-pyYAML~=6.0.12",
   "types-pytz~=2025.2",
   "databricks-labs-pylint~=0.4.0",

--- a/src/databricks/labs/lakebridge/transpiler/installers.py
+++ b/src/databricks/labs/lakebridge/transpiler/installers.py
@@ -8,17 +8,24 @@ import subprocess
 import sys
 import venv
 import xml.etree.ElementTree as ET
-from json import dump, loads
+from json import dump
 from pathlib import Path
 from shutil import rmtree
-from typing import Any, Literal
-from urllib import request
-from urllib.error import HTTPError, URLError
+from typing import Literal
 from zipfile import ZipFile
 
+import requests
+from requests.exceptions import HTTPError
+
+from databricks.labs.blueprint.installation import RootJsonValue
 from databricks.labs.lakebridge.transpiler.repository import TranspilerRepository
 
 logger = logging.getLogger(__name__)
+
+
+# This is not the total timeout for a request, but rather a timeout when waiting for the response
+# to start once the request has been sent.
+_DEFAULT_HTTP_TIMEOUT = 60  # seconds
 
 
 class _PathBackup:
@@ -154,14 +161,20 @@ class WheelInstaller(ArtifactInstaller):
 
     @classmethod
     def get_latest_artifact_version_from_pypi(cls, product_name: str) -> str | None:
+        url = f"https://pypi.org/pypi/{product_name}/json"
+        response = requests.get(url, timeout=_DEFAULT_HTTP_TIMEOUT)
         try:
-            with request.urlopen(f"https://pypi.org/pypi/{product_name}/json") as server:
-                text: bytes = server.read()
-            data: dict[str, Any] = loads(text)
-            return data.get("info", {}).get('version', None)
+            response.raise_for_status()
+            data: RootJsonValue = response.json()
         except HTTPError as e:
             logger.error(f"Error while fetching PyPI metadata: {product_name}", exc_info=e)
             return None
+        logger.debug(f"PyPI metadata for {product_name}: {data}")
+        match data:
+            case {"info": {"version": str(version), **_ignored}, **_also_ignored}:
+                return version
+            case _:
+                return None
 
     def __init__(
         self,
@@ -283,9 +296,11 @@ class MavenInstaller(ArtifactInstaller):
     @classmethod
     def get_current_maven_artifact_version(cls, group_id: str, artifact_id: str) -> str | None:
         url = cls.artifact_metadata_url(group_id, artifact_id)
+        response = requests.get(url, timeout=_DEFAULT_HTTP_TIMEOUT)
         try:
-            with request.urlopen(url) as server:
-                text = server.read()
+            response.raise_for_status()
+            # Content will be XML.
+            text = response.text
         except HTTPError as e:
             logger.error(f"Error while fetching maven metadata: {group_id}:{artifact_id}", exc_info=e)
             return None
@@ -318,14 +333,20 @@ class MavenInstaller(ArtifactInstaller):
             logger.warning(f"Skipping download of {group_id}:{artifact_id}:{version}; target already exists: {target}")
             return True
         url = cls.artifact_url(group_id, artifact_id, version, classifier, extension)
+        tmp_target = target.parent / f".{target.name}.download"
+        request = requests.get(url, stream=True, timeout=_DEFAULT_HTTP_TIMEOUT)
         try:
-            path, _ = request.urlretrieve(url)
-            logger.debug(f"Downloaded maven artefact from {url} to {path}")
-        except URLError as e:
+            request.raise_for_status()
+            with tmp_target.open("wb") as f:
+                for chunk in request.iter_content(chunk_size=8192):
+                    if chunk:
+                        f.write(chunk)
+            logger.debug(f"Downloaded maven artefact: {url} -> {tmp_target}")
+        except HTTPError as e:
             logger.error(f"Unable to download maven artefact: {group_id}:{artifact_id}:{version}", exc_info=e)
             return False
-        logger.debug(f"Moving {path} to {target}")
-        shutil.move(path, target)
+        logger.debug(f"Moving {tmp_target} to {target}")
+        shutil.move(tmp_target, target)
         logger.info(f"Successfully installed: {group_id}:{artifact_id}:{version}")
         return True
 

--- a/tests/integration/transpile/test_installers.py
+++ b/tests/integration/transpile/test_installers.py
@@ -24,7 +24,7 @@ def test_downloads_from_maven(tmp_path: Path) -> None:
 
 
 def test_gets_pypi_artifact_version() -> None:
-    version = WheelInstaller.get_latest_artifact_version_from_pypi("databricks-labs-remorph")
+    version = WheelInstaller.get_latest_artifact_version_from_pypi("databricks-labs-lakebridge")
     assert version is not None
     check_valid_version(version)
 


### PR DESCRIPTION
## Changes

This PR updates our Maven and wheel installers to use the `requests` package for making HTTP calls instead of Python's builtin `urllib`. Although we try to avoid additional dependencies, it seems that Maven Central's CDN (CloudFlare) is blocking HTTP calls include `Python-urllib/3.xx` in the user-agent. We don't believe this is specifically targeted at us: we are acting as a consumer application (similar to maven/pip) and shouldn't be producing unreasonably amounts of traffic.

### Caveats/things to watch out for when reviewing:

We still use the standard UA, but should extend it to identify Databricks (and this application). I've added `TODO` markers for this as an improvement.

### Linked issues

Resolves #2064 

### Functionality

- affects existing commands:

  - `databricks labs lakebridge install-transpile`
  - `databricks labs install lakebridge` (if installed transpilers are detected)

### Tests

- [ ] manually tested
- [ ] existing integration tests
