### PR TITLE
Add Switch transpiler with `--include-llm-transpiler` flag

### DIFF
--- a/labs.yml
+++ b/labs.yml
@@ -64,5 +64,8 @@ commands:
       - name: interactive
         description: "Whether installing in interactive mode, which may prompt for configuration settings."
         default: auto
+      - name: include-llm-transpiler
+        description: "Include LLM-based transpiler in installation"
+        default: false
   - name: configure-reconcile
     description: "Configure Necessary Reconcile Dependencies"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -445,7 +445,7 @@ bad-functions = ["map", "input"]
 # ignored-parents =
 
 # Maximum number of arguments for function / method.
-max-args = 12
+max-args = 13
 
 # Maximum number of attributes for a class (see R0902).
 max-attributes = 13

--- a/src/databricks/labs/lakebridge/cli.py
+++ b/src/databricks/labs/lakebridge/cli.py
@@ -614,6 +614,7 @@ def install_transpile(
     w: WorkspaceClient,
     artifact: str | None = None,
     interactive: str | None = None,
+    include_llm_transpiler: bool = False,
     transpiler_repository: TranspilerRepository = TranspilerRepository.user_home(),
 ) -> None:
     """Install or upgrade the Lakebridge transpilers."""
@@ -622,9 +623,13 @@ def install_transpile(
     ctx.add_user_agent_extra("cmd", "install-transpile")
     if artifact:
         ctx.add_user_agent_extra("artifact-overload", Path(artifact).name)
+    if include_llm_transpiler:
+        ctx.add_user_agent_extra("include-llm-transpiler", "true")
     user = w.current_user
     logger.debug(f"User: {user}")
-    transpile_installer = installer(w, transpiler_repository, is_interactive=is_interactive)
+    transpile_installer = installer(
+        w, transpiler_repository, is_interactive=is_interactive, include_llm_transpiler=include_llm_transpiler
+    )
     transpile_installer.run(module="transpile", artifact=artifact)
 
 


### PR DESCRIPTION
## Changes
This PR adds Switch, an LLM-powered transpiler, as an optional component in Lakebridge's `install-transpile` workflow. Switch installation is controlled by the new `--include-llm-transpiler` flag.

### What does this PR do?
Implements complete Switch transpiler integration with idempotent installation, workspace deployment, job management, and resource configuration including Unity Catalog Volume for Switch.

### Relevant implementation details
**CLI Integration**:
- Add `--include-llm-transpiler` flag to `install-transpile` command (default: `false`)
- Switch installation is opt-in, allowing users to choose between LSP-only or LLM-powered transpilation
- Bladebridge and Morpheus continue to install by default

**SwitchInstaller Implementation**:
- Extends `TranspilerInstaller` with unified constructor signature
- WheelInstaller pattern for PyPI package management (`databricks-switch-plugin`)
- Workspace deployment: uploads Switch package from site-packages to `/Users/{user}/.lakebridge/switch/`
- Job creation: creates `LAKEBRIDGE_Switch` job with NotebookTask for parallel LLM processing
- Resource configuration: prompts for catalog, schema, and volume for Switch
- Idempotent behavior: supports reinstallation after uninstall with full recovery

**Uninstall Integration**:
- Removes Switch job from workspace via InstallState
- Logs manual cleanup instructions for validation schema and Switch resources (catalog, schema, volume)
- Integrated into `databricks labs uninstall lakebridge` workflow

### Caveats/things to watch out for when reviewing:
- **Opt-in by default**: Switch is NOT installed by default. Users must explicitly specify `--include-llm-transpiler` flag to install Switch
- **Telemetry tracking**: Added `include-llm-transpiler` flag to user agent telemetry for usage tracking
- **Pylint configuration**: Updated `max-args` from 12 to 13 in `pyproject.toml` to accommodate new CLI parameter
- **Resource lifecycle**: Catalog, schema, and volume for Switch are prompted during install but require manual cleanup after uninstall
- **Job management**: Switch job is tracked in InstallState and managed independently from Reconciliation jobs
- **Package dependency**: Requires `databricks-switch-plugin>=0.1.0` from PyPI
- 
### Linked issues
Resolves #2048 

### Functionality

- [ ] added relevant user documentation
- [ ] added new CLI command
- [x] modified existing command: `databricks labs lakebridge install-transpile` (adds `--include-llm-transpiler` flag and Switch installation support)
- [x] modified existing command: `databricks labs uninstall lakebridge` (adds Switch job and resource cleanup)

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [x] added unit tests
- [ ] added integration tests
