### PR TITLE
Freshen project development dependencies

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -38,7 +38,7 @@ jobs:
           python-version: '3.10'
 
       - name: Install hatch
-        run: pip install hatch==1.14.1 'click<8.3.0' # https://github.com/pallets/click/issues/3065
+        run: pip install hatch==1.14.2
 
       - name: Install MSSQL ODBC Driver
         run: |

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,7 +15,7 @@ on:
       - main
 
 env:
-  HATCH_VERSION: 1.14.1
+  HATCH_VERSION: 1.14.2
 
 jobs:
   test-python:
@@ -34,7 +34,7 @@ jobs:
           python-version: '3.10'
 
       - name: Install hatch
-        run: pip install hatch==$HATCH_VERSION 'click<8.3.0' # https://github.com/pallets/click/issues/3065
+        run: pip install hatch==$HATCH_VERSION
 
       - name: Run unit tests
         run: hatch run test
@@ -61,7 +61,7 @@ jobs:
           python-version: '3.10'
 
       - name: Install hatch
-        run: pip install hatch==$HATCH_VERSION 'click<8.3.0' # https://github.com/pallets/click/issues/3065
+        run: pip install hatch==$HATCH_VERSION
 
       - name: Setup Spark Remote
         run: |
@@ -94,7 +94,7 @@ jobs:
           python-version: 3.10.x
 
       - name: Install hatch
-        run: pip install hatch==$HATCH_VERSION 'click<8.3.0' # https://github.com/pallets/click/issues/3065
+        run: pip install hatch==$HATCH_VERSION
 
       - name: Reformat code
         run: make fmt
@@ -147,7 +147,7 @@ jobs:
           python-version: 3.10.x
 
       - name: Install hatch
-        run: pip install hatch==$HATCH_VERSION 'click<8.3.0' # https://github.com/pallets/click/issues/3065
+        run: pip install hatch==$HATCH_VERSION
 
       - name: Install Databricks CLI
         uses: databricks/setup-cli@main
@@ -199,11 +199,11 @@ jobs:
 
     - name: Install hatch (Windows)
       if: runner.os == 'Windows'
-      run: pip install hatch==$env:HATCH_VERSION 'click<8.3.0' # https://github.com/pallets/click/issues/3065
+      run: pip install hatch==$env:HATCH_VERSION
 
     - name: Install hatch (Non-Windows)
       if: runner.os != 'Windows'
-      run: pip install hatch==$HATCH_VERSION 'click<8.3.0' # https://github.com/pallets/click/issues/3065
+      run: pip install hatch==$HATCH_VERSION
 
     - name: Install Databricks CLI
       uses: databricks/setup-cli@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Build wheels
         run: |
-          pip install hatch==1.14.1 'click<8.3.0' # https://github.com/pallets/click/issues/3065
+          pip install hatch==1.14.2
           hatch build
 
       - name: Draft release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "Operating System :: MacOS",
     "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX :: Linux",
     "Topic :: Utilities",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,26 +68,25 @@ path = ".venv"
 dependencies = [
   "pylint~=3.2.2",
   "pylint-pytest==2.0.0a0",
-  "coverage[toml]~=7.8.0",
-  "pytest~=8.3.5",
-  "pytest-cov>=5.0.0,<6.0.0",
-  "pytest-asyncio~=0.26.0",
-  "pytest-xdist~=3.5.0",
+  "coverage[toml]~=7.10.7",
+  "pytest~=8.4.2",
+  "pytest-cov~=7.0.0",
+  "pytest-asyncio~=1.2.0",
+  "pytest-xdist~=3.8.0",
   "pytest-timeout~=2.4.0",
-  "black~=25.1.0",
-  "ruff~=0.11.6",
+  "black~=25.9.0",
+  "ruff~=0.13.2",
   "databricks-connect==15.1",
   "types-requests>=2.28.1,<3",  # Matches the 'requests' above.
   "types-pyYAML~=6.0.12",
   "types-pytz~=2025.2",
   "databricks-labs-pylint~=0.4.0",
   "databricks-labs-pytester>=0.3.0",
-  "mypy~=1.10.0",
+  "mypy~=1.18.2",
   "numpy~=1.26.4",
   "pandas~=2.3.1",
   "pandas-stubs~=2.3.0.250703",
   "cattrs>=25.2.0",
-  "click<8.3.0", # https://github.com/pallets/click/issues/3065 for ruff
   "faker"
 ]
 
@@ -153,7 +152,6 @@ lint.ignore = [
   # Ignore Exception must not use a string literal, assign to variable first
   "EM101",
   "PLR2004",
-  "UP038", # Use `X | Y` in `isinstance` call instead of `(X, Y)`
 ]
 extend-exclude = [
   "notebooks/*.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "Operating System :: MacOS",
     "Operating System :: Microsoft :: Windows",
-    "Topic :: Software Development :: Libraries",
     "Topic :: Utilities",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,8 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
     "Environment :: Console",
     "Framework :: Pytest",

--- a/src/databricks/labs/lakebridge/deployment/configurator.py
+++ b/src/databricks/labs/lakebridge/deployment/configurator.py
@@ -83,7 +83,7 @@ class ResourceConfigurator:
         pro_warehouses = {"[Create new PRO SQL warehouse]": "create_new"} | {
             f"{_.name} ({_.id}, {warehouse_type(_)}, {_.state.value})": _.id
             for _ in self._ws.warehouses.list()
-            if _.warehouse_type == EndpointInfoWarehouseType.PRO
+            if _.state is not None and _.warehouse_type == EndpointInfoWarehouseType.PRO
         }
         warehouse_id = self._prompts.choice_from_dict(
             "Select PRO or SERVERLESS SQL warehouse",

--- a/src/databricks/labs/lakebridge/transpiler/installers.py
+++ b/src/databricks/labs/lakebridge/transpiler/installers.py
@@ -475,7 +475,9 @@ class MorpheusInstaller(TranspilerInstaller):
                 logger.warning(f"Java found, but could not determine the version: {java_executable}.")
                 return False
             case (java_executable, bytes(raw_version)):
-                logger.warning(f"Java found ({java_executable}), but could not parse the version:\n{raw_version}")
+                # Strip leading/trailing b' and ' from the repr.
+                display_version = repr(raw_version)[2:-1]  # Strip b'' from the repr.
+                logger.warning(f"Java found ({java_executable}), but could not parse the version:\n{display_version}")
                 return False
             case (java_executable, tuple(old_version)) if old_version < (11, 0, 0, 0):
                 version_str = ".".join(str(v) for v in old_version)

--- a/src/databricks/labs/lakebridge/transpiler/sqlglot/parsers/snowflake.py
+++ b/src/databricks/labs/lakebridge/transpiler/sqlglot/parsers/snowflake.py
@@ -75,7 +75,7 @@ def _parse_to_timestamp(args: list) -> exp.StrToTime | exp.UnixToTime | exp.Time
         # case: <variant_expr> or other expressions such as columns
         return exp.TimeStrToTime.from_arg_list(args)
 
-    if first_arg.is_string:
+    if first_arg is not None and first_arg.is_string:
         if is_int(first_arg.this):
             # case: <integer>
             return exp.UnixToTime.from_arg_list(args)


### PR DESCRIPTION
## Changes

This PR:

 - Updates the project metadata.
 - Freshens the development tooling that we use, along with minor corresponding adjustments  to the code to satisfy newer versions of the tools.

### Relevant implementation details

Updated development tools:

 - Black (formatting)
 - Hatch
 - Mypy (static type checker)
 - Pytest (and the plugins we use: asyncio/cov/xdist)
 - Ruff (linter)

Pylint has been left alone, because it tends to be a bit more complicated.

### Caveats/things to watch out for when reviewing

The updated version of mypy flagged a few minor issues in the code, but these are reviewable by inspection.

### Tests

- manually tested
- existing unit tests
- existing integration tests
