### PR TITLE
Minor pip improvements during `install-transpile`

### DIFF
--- a/src/databricks/labs/lakebridge/transpiler/installers.py
+++ b/src/databricks/labs/lakebridge/transpiler/installers.py
@@ -238,6 +238,7 @@ class WheelInstaller(ArtifactInstaller):
             self._venv_exec_cmd,
             "-m",
             "pip",
+            "--require-virtualenv",
             "--disable-pip-version-check",
             "install",
             to_install,

--- a/src/databricks/labs/lakebridge/transpiler/installers.py
+++ b/src/databricks/labs/lakebridge/transpiler/installers.py
@@ -242,6 +242,7 @@ class WheelInstaller(ArtifactInstaller):
             "--disable-pip-version-check",
             "install",
             to_install,
+            "--only-binary=:all:",
         ]
         result = subprocess.run(command, stdin=sys.stdin, stdout=sys.stdout, stderr=sys.stderr, check=False)
         result.check_returncode()


### PR DESCRIPTION
## Changes

This PR updates the way we invoke `pip` during `install-transpile`:

 - It now verifies that it's running within a virtual environment.
 - It only installs binary packages, meaning we won't accidentally try to compile a source package (if found as a dependency).

### Functionality

- affects existing command: `databricks labs lakebridge install-transpile`

### Tests

- manually tested
