### PR TITLE
Update `transpile` to support `--overrides-path` and `--target-technology` arguments

### DIFF
--- a/labs.yml
+++ b/labs.yml
@@ -26,6 +26,12 @@ commands:
       - name: source-dialect
         description: Dialect name as selected during `install-transpile` or refer to documentation
         default: null
+      - name: overrides-file
+        description: Path to a file containing transpiler overrides, if supported by the transpiler in use.
+        default: null
+      - name: target-technology
+        description: Target technology to use for code generation, if supported by the transpiler in use.
+        default: null
       - name: input-source
         description: Input Script Folder or File
         default: null

--- a/labs.yml
+++ b/labs.yml
@@ -37,7 +37,7 @@ commands:
         default: null
       - name: skip-validation
         description: Validate Transpiled Code, default True validation skipped, False validate
-        default: true
+        default: "true"
       - name: catalog-name
         description: Catalog Name Applicable only when Validation Mode is DATABRICKS
         default: null

--- a/src/databricks/labs/lakebridge/cli.py
+++ b/src/databricks/labs/lakebridge/cli.py
@@ -16,7 +16,7 @@ from databricks.sdk import WorkspaceClient
 
 from databricks.labs.blueprint.cli import App
 from databricks.labs.blueprint.entrypoint import get_logger, is_in_debug
-from databricks.labs.blueprint.installation import RootJsonValue
+from databricks.labs.blueprint.installation import RootJsonValue, JsonObject
 from databricks.labs.blueprint.tui import Prompts
 
 
@@ -91,6 +91,8 @@ def transpile(
     w: WorkspaceClient,
     transpiler_config_path: str | None = None,
     source_dialect: str | None = None,
+    overrides_file: str | None = None,
+    target_technology: str | None = None,
     input_source: str | None = None,
     output_folder: str | None = None,
     error_file_path: str | None = None,
@@ -106,6 +108,8 @@ def transpile(
     checker = _TranspileConfigChecker(ctx.transpile_config, ctx.prompts, transpiler_repository)
     checker.use_transpiler_config_path(transpiler_config_path)
     checker.use_source_dialect(source_dialect)
+    checker.use_overrides_file(overrides_file)
+    checker.use_target_technology(target_technology)
     checker.use_input_source(input_source)
     checker.use_output_folder(output_folder)
     checker.use_error_file_path(error_file_path)
@@ -218,6 +222,36 @@ class _TranspileConfigChecker:
             self._source_dialect_override = source_dialect
 
     @staticmethod
+    def _validate_overrides_file(overrides_file: str, msg: str) -> None:
+        """Validate the overrides file: it must be a valid path that exists."""
+        # Note: in addition to this check, later we verify the transpiler supports it.
+        if not Path(overrides_file).exists():
+            raise_validation_exception(msg)
+
+    def use_overrides_file(self, overrides_file: str | None) -> None:
+        if overrides_file is not None:
+            logger.debug(f"Setting overrides_file to: {overrides_file!r}")
+            msg = f"Invalid path for '--overrides-file', does not exist: {overrides_file}"
+            self._validate_overrides_file(overrides_file, msg)
+            try:
+                self._set_config_transpiler_option("overrides-file", overrides_file)
+            except ValueError:
+                # TODO: Update the `config.yml` format to disallow incompatible `transpiler_options`.
+                msg = "Cannot use --overrides-file; workspace config.yml has incompatible transpiler_options."
+                raise_validation_exception(msg)
+
+    def use_target_technology(self, target_technology: str | None) -> None:
+        if target_technology is not None:
+            logger.debug(f"Setting target_technology to: {target_technology!r}")
+            # Cannot validate this here: depends on the transpiler engine, and will be checked later.
+            try:
+                self._set_config_transpiler_option("target-tech", target_technology)
+            except ValueError:
+                # TODO: Update the `config.yml` format to disallow incompatible `transpiler_options`.
+                msg = "Cannot use --target-technology; workspace config.yml has incompatible transpiler_options."
+                raise_validation_exception(msg)
+
+    @staticmethod
     def _validate_input_source(input_source: str, msg: str) -> None:
         """Validate the input source: it must be a path that exists."""
         if not Path(input_source).exists():
@@ -320,6 +354,19 @@ class _TranspileConfigChecker:
         if schema_name:
             logger.debug(f"Setting schema_name to: {schema_name!r}")
             self._config = dataclasses.replace(self._config, schema_name=schema_name)
+
+    def _set_config_transpiler_option(self, flag: str, value: str) -> None:
+        transpiler_options: JsonObject
+        match self._config.transpiler_options:
+            case None:
+                transpiler_options = {flag: value}
+            case Mapping() as found_options:
+                transpiler_options = {**found_options, flag: value}
+            case found_options:
+                # TODO: Update `config.yml' to constrain `transpiler_options` to be a dict[str, str].
+                msg = f"Incompatible transpiler options configured, must be a mapping: {found_options!r}"
+                raise ValueError(msg)
+        self._config = dataclasses.replace(self._config, transpiler_options=transpiler_options)
 
     def _configure_transpiler_config_path(self, source_dialect: str) -> TranspileEngine | None:
         """Configure the transpiler config path based on the requested source dialect."""
@@ -450,6 +497,8 @@ class _TranspileConfigChecker:
         transpiler_options = self._config.transpiler_options
         if not isinstance(transpiler_options, Mapping):
             return
+        # Only checks if the option is present, does not validate the value.
+        # TODO: Validate the value for CHOICE/FORCE/CONFIRM options.
         checked_options = {
             option.flag: (
                 transpiler_options[option.flag]

--- a/tests/unit/test_cli_transpile.py
+++ b/tests/unit/test_cli_transpile.py
@@ -41,11 +41,20 @@ def stubbed_transpiler_config_path(tmp_path: Path) -> Path:
         "options": {
             "all": [
                 {
-                    "flag": "-experimental",
-                    "method": "CONFIRM",
-                    "prompt": "Do you want to use the experimental Databricks generator ?",
+                    "flag": "overrides-file",
+                    "method": "QUESTION",
+                    "prompt": "Specify the config file to override",
+                    "default": "<none>",
                 }
-            ]
+            ],
+            "informatica pc": [
+                {
+                    "flag": "target-tech",
+                    "method": "CHOICE",
+                    "prompt": "Specify which technology should be generated",
+                    "choices": ["SPARKSQL", "PYSPARK"],
+                },
+            ],
         },
     }
 
@@ -288,6 +297,101 @@ def test_transpile_with_invalid_input_source(
         cli.transpile(w=ws, input_source="invalid_path", transpiler_repository=transpiler_repository)
 
 
+def test_transpile_overrides_file_specified(
+    mock_cli_for_transpile,
+    transpiler_repository: TranspilerRepository,
+    tmp_path: Path,
+) -> None:
+    """Verify that the overrides file can be manually specified and is passed to the transpiler."""
+    ws, cfg, _, do_transpile = mock_cli_for_transpile
+    overrides_path = tmp_path / "overrides.json"
+    overrides_path.write_text("{}")
+
+    cli.transpile(
+        w=ws,
+        transpiler_config_path=cfg.transpiler_config_path,
+        source_dialect=cfg.source_dialect,
+        overrides_file=str(overrides_path),
+        input_source=cfg.input_source,
+        output_folder=cfg.output_folder,
+        error_file_path=cfg.error_file_path,
+        skip_validation=str(cfg.skip_validation),
+        catalog_name=cfg.catalog_name,
+        schema_name=cfg.schema_name,
+        transpiler_repository=transpiler_repository,
+    )
+    do_transpile.assert_called_once_with(
+        ws,
+        ANY,
+        TranspileConfig(
+            transpiler_config_path=cfg.transpiler_config_path,
+            source_dialect=cfg.source_dialect,
+            input_source=cfg.input_source,
+            output_folder=cfg.output_folder,
+            error_file_path=cfg.error_file_path,
+            sdk_config=cfg.sdk_config,
+            skip_validation=cfg.skip_validation,
+            catalog_name=cfg.catalog_name,
+            schema_name=cfg.schema_name,
+            transpiler_options={"overrides-file": str(overrides_path)},
+        ),
+    )
+
+
+def test_transpile_invalid_overrides_file_specified(
+    mock_cli_for_transpile,
+    transpiler_repository: TranspilerRepository,
+    tmp_path: Path,
+) -> None:
+    """Verify that the overrides file argument is checked for whether it is a valid path."""
+    ws, _, _, _ = mock_cli_for_transpile
+    with pytest.raises(
+        ValueError, match=re.escape("Invalid path for '--overrides-file', does not exist: does_not_exist.json")
+    ):
+        cli.transpile(w=ws, overrides_file="does_not_exist.json", transpiler_repository=transpiler_repository)
+
+
+def test_transpile_target_technology_specified(
+    mock_cli_for_transpile,
+    transpiler_repository: TranspilerRepository,
+) -> None:
+    """Verify that the target technology can be manually specified and is passed to the transpiler."""
+    ws, cfg, set_cfg, do_transpile = mock_cli_for_transpile
+    cfg.source_dialect = "informatica pc"
+    cfg.transpiler_options = {"overrides-file": "a_file.json"}
+    set_cfg(cfg)
+
+    cli.transpile(
+        w=ws,
+        transpiler_config_path=cfg.transpiler_config_path,
+        source_dialect=cfg.source_dialect,
+        target_technology="PYSPARK",
+        input_source=cfg.input_source,
+        output_folder=cfg.output_folder,
+        error_file_path=cfg.error_file_path,
+        skip_validation=str(cfg.skip_validation),
+        catalog_name=cfg.catalog_name,
+        schema_name=cfg.schema_name,
+        transpiler_repository=transpiler_repository,
+    )
+    do_transpile.assert_called_once_with(
+        ws,
+        ANY,
+        TranspileConfig(
+            transpiler_config_path=cfg.transpiler_config_path,
+            source_dialect=cfg.source_dialect,
+            input_source=cfg.input_source,
+            output_folder=cfg.output_folder,
+            error_file_path=cfg.error_file_path,
+            sdk_config=cfg.sdk_config,
+            skip_validation=cfg.skip_validation,
+            catalog_name=cfg.catalog_name,
+            schema_name=cfg.schema_name,
+            transpiler_options={**cfg.transpiler_options, "target-tech": "PYSPARK"},
+        ),
+    )
+
+
 def test_transpile_with_valid_inputs(
     mock_cli_for_transpile, transpiler_config_path: Path, transpiler_repository: TranspilerRepository
 ) -> None:
@@ -397,10 +501,17 @@ def test_describe_transpile(mock_cli_transpile_no_config, transpiler_repository:
     (out, _) = capsys.readouterr()
     json_description = json.loads(out)
 
-    experimental_option = {
-        "flag": "-experimental",
-        "method": "CONFIRM",
-        "prompt": "Do you want to use the experimental Databricks generator ?",
+    overrides_file_option = {
+        "flag": "overrides-file",
+        "method": "QUESTION",
+        "prompt": "Specify the config file to override",
+        "default": "<none>",
+    }
+    target_tech_option = {
+        "flag": "target-tech",
+        "method": "CHOICE",
+        "prompt": "Specify which technology should be generated",
+        "choices": ["SPARKSQL", "PYSPARK"],
     }
 
     assert json_description == {
@@ -414,8 +525,8 @@ def test_describe_transpile(mock_cli_transpile_no_config, transpiler_repository:
                 "config-path": str(transpiler_repository.transpilers_path() / "stub-transpiler" / "lib" / "config.yml"),
                 "versions": {"installed": None, "latest": None},
                 "supported-dialects": {
-                    "informatica pc": {"options": [experimental_option]},
-                    "snowflake": {"options": [experimental_option]},
+                    "informatica pc": {"options": [overrides_file_option, target_tech_option]},
+                    "snowflake": {"options": [overrides_file_option]},
                 },
             }
         ],


### PR DESCRIPTION
## Changes

This PR updates our `transpile` command to support some additional arguments:

 - `--overrides-file`: for specifying an overrides (JSON) file with BB-based conversions.
 - `--target-technology`: for specifying the target technology when using BB to perform ETL conversions.

### Linked issues

Resolves #2070.

### Functionality

- [ ] added relevant user documentation
- [X] modified existing command: `databricks labs lakebridge install`

### Tests

- [ ] manually tested
- [X] added unit tests
- [ ] added integration tests
