### PR TITLE
bump blueprint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
   "standard-distutils~=3.11.9; python_version>='3.11'",
   "databricks-bb-analyzer~=0.1.9",
   "sqlglot==26.1.3",
-  "databricks-labs-blueprint[yaml]>=0.11.3,<0.12.0",
+  "databricks-labs-blueprint[yaml]>=0.11.4,<0.12.0",
   "databricks-labs-lsql==0.16.0",
   "cryptography>=44.0.2,<45.1.0",
   "pyodbc~=5.2.0",

--- a/src/databricks/labs/lakebridge/deployment/configurator.py
+++ b/src/databricks/labs/lakebridge/deployment/configurator.py
@@ -98,6 +98,10 @@ class ResourceConfigurator:
                 max_num_clusters=1,
             )
             warehouse_id = new_warehouse.id
+        # Since prompts choice type has changed in blueprint 0.11.4 to be more generic from earlier permissive type
+        # mypy correctly complains about the type mismatch, so added this below check to handle errors
+        if warehouse_id is None:
+            raise SystemExit("Cannot continue installation, without a valid warehouse. Aborting the installation.")
         return warehouse_id
 
     def has_necessary_catalog_access(

--- a/src/databricks/labs/lakebridge/deployment/configurator.py
+++ b/src/databricks/labs/lakebridge/deployment/configurator.py
@@ -98,8 +98,7 @@ class ResourceConfigurator:
                 max_num_clusters=1,
             )
             warehouse_id = new_warehouse.id
-        # Since prompts choice type has changed in blueprint 0.11.4 to be more generic from earlier permissive type
-        # mypy correctly complains about the type mismatch, so added this below check to handle errors
+
         if warehouse_id is None:
             raise SystemExit("Cannot continue installation, without a valid warehouse. Aborting the installation.")
         return warehouse_id


### PR DESCRIPTION
<!-- REMOVE IRRELEVANT COMMENTS BEFORE CREATING A PULL REQUEST -->
## Changes
<!-- Summary of your changes that are easy to understand. Add screenshots when necessary, they're helpful to illustrate the before and after state -->
### What does this PR do?

- Bump Blueprint to 0.11.4, which introduces password prompting.
- Since the prompt choice type has changed in blueprint 0.11.4 to be more generic from the earlier permissive type, mypy correctly complains about the type mismatch, so I added a new warhouse_id handler for checking None.

### Relevant implementation details

### Caveats/things to watch out for when reviewing:

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #..

### Functionality

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs lakebridge ...`
- [ ] ... +add your own

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
