### PR TITLE
Add java 25 to the list of versions we verify we can check

### DIFF
--- a/src/databricks/labs/lakebridge/transpiler/installers.py
+++ b/src/databricks/labs/lakebridge/transpiler/installers.py
@@ -540,6 +540,10 @@ class MorpheusInstaller(TranspilerInstaller):
         #   openjdk version "24.0.1" 2025-04-15
         #   OpenJDK Runtime Environment Temurin-24.0.1+9 (build 24.0.1+9)
         #   OpenJDK 64-Bit Server VM Temurin-24.0.1+9 (build 24.0.1+9, mixed mode)
+        # Or:
+        #   openjdk version "25" 2025-09-16 LTS
+        #   OpenJDK Runtime Environment Temurin-25+36 (build 25+36-LTS)
+        #   OpenJDK 64-Bit Server VM Temurin-25+36 (build 25+36-LTS, mixed mode, sharing)
         match = cls._java_version_pattern.search(version)
         if not match:
             logger.debug(f"Could not parse java version: {version!r}")

--- a/tests/unit/transpiler/test_installers.py
+++ b/tests/unit/transpiler/test_installers.py
@@ -99,8 +99,8 @@ def test_java_version_parse(version: str, lts_suffix: bool, expected: tuple[int,
     """Verify that the Java version parsing works correctly."""
     # Format reference: https://docs.oracle.com/en/java/javase/11/install/version-string-format.html
     # The version string for these releases looks the same, except that as of 25 the "LTS" suffix can be added.
-    lts_suffix = " LTS" if lts_suffix else ""
-    version_output = f'openjdk version "{version}" 2025-06-19{lts_suffix}'
+    suffix = " LTS" if lts_suffix else ""
+    version_output = f'openjdk version "{version}" 2025-06-19{suffix}'
     parsed = FriendOfMorpheusInstaller.parse_java_version(version_output)
     assert parsed == expected
 

--- a/tests/unit/transpiler/test_installers.py
+++ b/tests/unit/transpiler/test_installers.py
@@ -76,29 +76,31 @@ class FriendOfMorpheusInstaller(MorpheusInstaller):
 
 
 @pytest.mark.parametrize(
-    ("version", "expected"),
+    ("version", "lts_suffix", "expected"),
     (
         # Real examples.
-        pytest.param("1.8.0_452", None, id="1.8.0_452"),
-        pytest.param("11.0.27", (11, 0, 27, 0), id="11.0.27"),
-        pytest.param("17.0.15", (17, 0, 15, 0), id="17.0.15"),
-        pytest.param("21.0.7", (21, 0, 7, 0), id="21.0.7"),
-        pytest.param("24.0.1", (24, 0, 1, 0), id="24.0.1"),
-        pytest.param("25", (25, 0, 0, 0), id="25"),
+        pytest.param("1.8.0_452", False, None, id="1.8.0_452"),
+        pytest.param("11.0.27", False, (11, 0, 27, 0), id="11.0.27"),
+        pytest.param("17.0.15", False, (17, 0, 15, 0), id="17.0.15"),
+        pytest.param("21.0.7", False, (21, 0, 7, 0), id="21.0.7"),
+        pytest.param("24.0.1", False, (24, 0, 1, 0), id="24.0.1"),
+        pytest.param("25", True, (25, 0, 0, 0), id="25"),
         # All digits.
-        pytest.param("1.2.3.4", (1, 2, 3, 4), id="1.2.3.4"),
+        pytest.param("1.2.3.4", False, (1, 2, 3, 4), id="1.2.3.4"),
         # Trailing zeros can be omitted.
-        pytest.param("1.2.3", (1, 2, 3, 0), id="1.2.3"),
-        pytest.param("1.2", (1, 2, 0, 0), id="1.2"),
-        pytest.param("1", (1, 0, 0, 0), id="1"),
+        pytest.param("1.2.3", False, (1, 2, 3, 0), id="1.2.3"),
+        pytest.param("1.2", False, (1, 2, 0, 0), id="1.2"),
+        pytest.param("1", False, (1, 0, 0, 0), id="1"),
         # Another edge case.
-        pytest.param("", None, id="empty string"),
+        pytest.param("", False, None, id="empty string"),
     ),
 )
-def test_java_version_parse(version: str, expected: tuple[int, int, int, int] | None) -> None:
+def test_java_version_parse(version: str, lts_suffix: bool, expected: tuple[int, int, int, int] | None) -> None:
     """Verify that the Java version parsing works correctly."""
     # Format reference: https://docs.oracle.com/en/java/javase/11/install/version-string-format.html
-    version_output = f'openjdk version "{version}" 2025-06-19'
+    # The version string for these releases looks the same, except that as of 25 the "LTS" suffix can be added.
+    lts_suffix = " LTS" if lts_suffix else ""
+    version_output = f'openjdk version "{version}" 2025-06-19{lts_suffix}'
     parsed = FriendOfMorpheusInstaller.parse_java_version(version_output)
     assert parsed == expected
 

--- a/tests/unit/transpiler/test_installers.py
+++ b/tests/unit/transpiler/test_installers.py
@@ -84,6 +84,7 @@ class FriendOfMorpheusInstaller(MorpheusInstaller):
         pytest.param("17.0.15", (17, 0, 15, 0), id="17.0.15"),
         pytest.param("21.0.7", (21, 0, 7, 0), id="21.0.7"),
         pytest.param("24.0.1", (24, 0, 1, 0), id="24.0.1"),
+        pytest.param("25", (25, 0, 0, 0), id="25"),
         # All digits.
         pytest.param("1.2.3.4", (1, 2, 3, 4), id="1.2.3.4"),
         # Trailing zeros can be omitted.


### PR DESCRIPTION
## Changes

Java 25 changes slightly the format of the `-version` line. This PR updates the test that checks we can parse the versions to include this variant. (We could, no changes to the parser required.)

### Tests

- updated unit test