### PR TITLE
Fix (and improve) the CLI documentation in `labs.yml`

### DIFF
--- a/labs.yml
+++ b/labs.yml
@@ -19,7 +19,7 @@ commands:
         description: (Optional) The technology/platform of the sources to analyze
 
   - name: transpile
-    description: Transpile SQL script to Databricks SQL
+    description: Transpile SQL/ETL sources to Databricks-compatible code
     flags:
       - name: transpiler-config-path
         description: Path to the transpiler configuration file [Pluggable Transpilers] eg:- Morpheus/Bladebridge
@@ -43,16 +43,16 @@ commands:
       {{end}}
 
   - name: reconcile
-    description: Reconcile is an utility to streamline the reconciliation process between source data and target data residing on Databricks.
+    description: Reconcile source and target data residing on Databricks
 
   - name: aggregates-reconcile
-    description: Aggregates Reconcile is an utility to streamline the reconciliation process, specific aggregate metric is compared between source and target data residing on Databricks.
+    description: Reconcile source and target data residing on Databricks using aggregated metrics
 
   - name: configure-database-profiler
-    description: "Configure Database Profiler"
+    description: Configure database profiler
 
   - name: install-transpile
-    description: "Install & Configure Necessary Transpiler Dependencies"
+    description: Install & optionally configure 'transpile' dependencies
     flags:
       - name: artifact
         description: Local path to transpiler artifact
@@ -61,7 +61,7 @@ commands:
         default: auto
 
   - name: describe-transpile
-    description: "Describe installed transpilers."
+    description: Describe installed transpilers
     table_template: |-
       Transpiler\tInstalled Version\tPlugin Configuration
       ==========\t=================\t====================
@@ -73,4 +73,4 @@ commands:
       {{end}}
 
   - name: configure-reconcile
-    description: "Configure Necessary Reconcile Dependencies"
+    description: Configure 'reconcile' dependencies

--- a/labs.yml
+++ b/labs.yml
@@ -22,21 +22,21 @@ commands:
     description: Transpile SQL/ETL sources to Databricks-compatible code
     flags:
       - name: transpiler-config-path
-        description: Path to the transpiler configuration file [Pluggable Transpilers] eg:- Morpheus/Bladebridge
+        description: (Optional) Local `path` to the configuration file of the transpiler to use for conversion
       - name: source-dialect
-        description: Dialect name as selected during `install-transpile` or refer to documentation
+        description: (Optional) The source dialect to use when performing conversion
       - name: input-source
-        description: Input Script Folder or File
+        description: (Optional) Local `path` of the sources to be convert
       - name: output-folder
-        description: Output Location For Storing Transpiled Code, defaults to (Current Working Directory) `<pwd>/transpiled` folder
+        description: (Optional) Local `path` where converted code will be written
       - name: error-file-path
-        description: Output Location For Storing Errors, defaults to (Current Working Directory) `<pwd>/errors.log`
+        description: (Optional) Local `path` where a log of conversion errors (if any) will be written
       - name: skip-validation
-        description: Validate Transpiled Code, default True validation skipped, False validate
+        description: (Optional) Whether to skip validating the output ('true') after conversion or not ('false')
       - name: catalog-name
-        description: Catalog Name Applicable only when Validation Mode is DATABRICKS
+        description: (Optional) Catalog `name`, only used when validating converted code
       - name: schema-name
-        description: Schema Name Applicable only when Validation Mode is DATABRICKS
+        description: (Optional) Schema `name`, only used when validating converted code
     table_template: |-
       total_files_processed\ttotal_queries_processed\tanalysis_error_count\tparsing_error_count\tvalidation_error_count\tgeneration_error_count\terror_log_file
       {{range .}}{{.total_files_processed}}\t{{.total_queries_processed}}\t{{.analysis_error_count}}\t{{.parsing_error_count}}\t{{.validation_error_count}}\t{{.generation_error_count}}\t{{.error_log_file}}

--- a/labs.yml
+++ b/labs.yml
@@ -23,28 +23,21 @@ commands:
     flags:
       - name: transpiler-config-path
         description: Path to the transpiler configuration file [Pluggable Transpilers] eg:- Morpheus/Bladebridge
-        default: null
       - name: source-dialect
         description: Dialect name as selected during `install-transpile` or refer to documentation
-        default: null
       - name: input-source
         description: Input Script Folder or File
-        default: null
       - name: output-folder
         description: Output Location For Storing Transpiled Code, defaults to (Current Working Directory) `<pwd>/transpiled` folder
-        default: null
       - name: error-file-path
         description: Output Location For Storing Errors, defaults to (Current Working Directory) `<pwd>/errors.log`
-        default: null
       - name: skip-validation
         description: Validate Transpiled Code, default True validation skipped, False validate
         default: true
       - name: catalog-name
         description: Catalog Name Applicable only when Validation Mode is DATABRICKS
-        default: null
       - name: schema-name
         description: Schema Name Applicable only when Validation Mode is DATABRICKS
-        default: null
     table_template: |-
       total_files_processed\ttotal_queries_processed\tanalysis_error_count\tparsing_error_count\tvalidation_error_count\tgeneration_error_count\terror_log_file
       {{range .}}{{.total_files_processed}}\t{{.total_queries_processed}}\t{{.analysis_error_count}}\t{{.parsing_error_count}}\t{{.validation_error_count}}\t{{.generation_error_count}}\t{{.error_log_file}}
@@ -64,7 +57,6 @@ commands:
     flags:
       - name: artifact
         description: Local path to transpiler artifact
-        default: null
       - name: interactive
         description: "Whether installing in interactive mode, which may prompt for configuration settings."
         default: auto

--- a/labs.yml
+++ b/labs.yml
@@ -9,14 +9,14 @@ entrypoint: src/databricks/labs/lakebridge/cli.py
 min_python: 3.10
 commands:
   - name: analyze
-    description: Analyze source code from existing technology
+    description: Analyze existing non-Databricks database or ETL sources
     flags:
       - name: source-directory
-        description: (Optional) Source Directory to Analyze
+        description: (Optional) Local filesystem `path` of a directory containing sources to analyze
       - name: report-file
-        description: (Optional) Name of report file to write
+        description: (Optional) Local filesystem `path` of the analysis report file to write
       - name: source-tech
-        description: (Optional) Name of the Source System Technology you want to analyze
+        description: (Optional) The technology/platform of the sources to analyze
 
   - name: transpile
     description: Transpile SQL script to Databricks SQL

--- a/labs.yml
+++ b/labs.yml
@@ -55,9 +55,9 @@ commands:
     description: Install & optionally configure 'transpile' dependencies
     flags:
       - name: artifact
-        description: Local path to transpiler artifact
+        description: (Optional) Local `path` to a transpiler artifact to install instead of the default transpilers.
       - name: interactive
-        description: "Whether installing in interactive mode, which may prompt for configuration settings."
+        description: (Optional) Whether installing in interactive mode (`true|false|auto`); configuration settings are prompted for when interactive
         default: auto
 
   - name: describe-transpile

--- a/labs.yml
+++ b/labs.yml
@@ -17,6 +17,7 @@ commands:
         description: (Optional) Name of report file to write
       - name: source-tech
         description: (Optional) Name of the Source System Technology you want to analyze
+
   - name: transpile
     description: Transpile SQL script to Databricks SQL
     flags:
@@ -44,17 +45,20 @@ commands:
       - name: schema-name
         description: Schema Name Applicable only when Validation Mode is DATABRICKS
         default: null
-
     table_template: |-
       total_files_processed\ttotal_queries_processed\tanalysis_error_count\tparsing_error_count\tvalidation_error_count\tgeneration_error_count\terror_log_file
       {{range .}}{{.total_files_processed}}\t{{.total_queries_processed}}\t{{.analysis_error_count}}\t{{.parsing_error_count}}\t{{.validation_error_count}}\t{{.generation_error_count}}\t{{.error_log_file}}
       {{end}}
+
   - name: reconcile
     description: Reconcile is an utility to streamline the reconciliation process between source data and target data residing on Databricks.
+
   - name: aggregates-reconcile
     description: Aggregates Reconcile is an utility to streamline the reconciliation process, specific aggregate metric is compared between source and target data residing on Databricks.
+
   - name: configure-database-profiler
     description: "Configure Database Profiler"
+
   - name: install-transpile
     description: "Install & Configure Necessary Transpiler Dependencies"
     flags:
@@ -64,6 +68,7 @@ commands:
       - name: interactive
         description: "Whether installing in interactive mode, which may prompt for configuration settings."
         default: auto
+
   - name: describe-transpile
     description: "Describe installed transpilers."
     table_template: |-
@@ -75,5 +80,6 @@ commands:
       =========================
       {{range (index . "available-dialects")}} - {{ . }}
       {{end}}
+
   - name: configure-reconcile
     description: "Configure Necessary Reconcile Dependencies"

--- a/labs.yml
+++ b/labs.yml
@@ -33,7 +33,6 @@ commands:
         description: Output Location For Storing Errors, defaults to (Current Working Directory) `<pwd>/errors.log`
       - name: skip-validation
         description: Validate Transpiled Code, default True validation skipped, False validate
-        default: true
       - name: catalog-name
         description: Catalog Name Applicable only when Validation Mode is DATABRICKS
       - name: schema-name


### PR DESCRIPTION
## Changes

This PR updates the `labs.yml` file used by the Databricks CLI to locate and provide `--help` for `databricks labs lakebridge` and subcommands.

Changes include:

 - Fixing argument placeholders in flags; many of these were accidentally filled with misleading text.
 - Marking all flags as optional: we don't have any mandatory flags yet.
 - Consistent and concise styling of descriptions. For example, no trailing periods (`.`).
 - Removing `null` as default values; this is unnecessary.
 - Removing the `--skip-validation` default: it's incorrect because the default value comes from `config.yml` in the workspace, which in turn normally comes from the value provided during `install-transpile` (if any).

### Functionality

- [ ] updated relevant user documentation
- [X] modified existing commands:

      - `databricks labs lakebridge [--help]`
      - `databricks labs lakebridge aggregates-reconcile --help`
      - `databricks labs lakebridge analyse --help`
      - `databricks labs lakebridge configure-database-provider --help`
      - `databricks labs lakebridge configure-reconcile --help`
      - `databricks labs lakebridge describe-transpile --help`
      - `databricks labs lakebridge install-transpile --help`
      - `databricks labs lakebridge reconcile --help`
      - `databricks labs lakebridge transpile --help`

### Tests

- [X] manually tested