### PR TITLE
Fix profiler overwrite table semantics

### DIFF
--- a/src/databricks/labs/lakebridge/assessments/pipeline.py
+++ b/src/databricks/labs/lakebridge/assessments/pipeline.py
@@ -48,8 +48,6 @@ class PipelineClass:
         self._db_path = db_path.expanduser()
         self._create_dir(self._db_path.parent)
         self._cred_file_path = cred_file_path
-        # Tables recreated by a ddl step in this run; SQL overwrite inserts into them
-        # rather than DROP+CTAS so declared types are preserved.
         self._ddl_tables: set[str] = set()
 
     def execute(self) -> list[StepExecutionResult]:
@@ -166,8 +164,6 @@ class PipelineClass:
         logging.info(f"Executing DDL for table '{step.name}'")
 
         try:
-            # Always DROP + recreate so declared types apply on same-day reruns.
-            # MSSQL DDL uses CREATE TABLE IF NOT EXISTS; Oracle/Teradata use CREATE TABLE.
             with duckdb.connect(self._db_path) as conn:
                 conn.begin()
                 conn.execute(f"DROP TABLE IF EXISTS {step.name}")
@@ -231,7 +227,6 @@ class PipelineClass:
             raise RuntimeError(f"Script execution failed with exit code {process.returncode}")
 
     def _save_to_db(self, result: FetchResult, step_name: str, mode: str):
-        # Check row count and log appropriately and skip data insertion if 0 rows
         if not result.rows:
             logging.warning(
                 f"Query for step '{step_name}' returned 0 rows. Skipping table creation and data insertion."
@@ -242,35 +237,29 @@ class PipelineClass:
         logging.info(f"Query for step '{step_name}' returned {row_count} rows.")
 
         with duckdb.connect(self._db_path) as conn:
-            # Note: step_name is validated to be SQL-safe by Step.__post_init__
             table_exists = self._table_exists(conn, step_name)
             conn.begin()
             _result_frame = result.to_df()
 
             if mode == 'overwrite':
                 if step_name in self._ddl_tables:
-                    # DDL step just recreated an empty typed table; insert into it.
                     logging.debug(f"Inserting into DDL-owned table '{step_name}'")
                     conn.execute(f"INSERT INTO {step_name} SELECT * FROM _result_frame")
                 else:
-                    # Replace the relation so types follow this run's data, not a prior CTAS.
                     logging.debug(f"Replacing table '{step_name}' via DROP + CREATE AS SELECT")
                     conn.execute(f"DROP TABLE IF EXISTS {step_name}")
                     conn.execute(f"CREATE TABLE {step_name} AS SELECT * FROM _result_frame")
             elif table_exists:
-                # Append mode: insert into existing table (DuckDB handles type conversion)
                 statement = f"INSERT INTO {step_name} SELECT * FROM _result_frame"
                 logging.debug(f"Appending to existing table '{step_name}'")
                 logging.debug(f"Executing: {statement}")
                 conn.execute(statement)
             else:
-                # Table doesn't exist: create table with native types from query result
                 statement = f"CREATE TABLE {step_name} AS SELECT * FROM _result_frame"
                 logging.debug(f"Creating new table '{step_name}' with native types")
                 logging.debug(f"Executing: {statement}")
                 conn.execute(statement)
 
-            # Explicit commit before context exit
             conn.commit()
             logging.info(f"Successfully processed {row_count} rows for table '{step_name}'.")
 

--- a/src/databricks/labs/lakebridge/assessments/pipeline.py
+++ b/src/databricks/labs/lakebridge/assessments/pipeline.py
@@ -48,6 +48,9 @@ class PipelineClass:
         self._db_path = db_path.expanduser()
         self._create_dir(self._db_path.parent)
         self._cred_file_path = cred_file_path
+        # Tables recreated by a ddl step in this run; SQL overwrite inserts into them
+        # rather than DROP+CTAS so declared types are preserved.
+        self._ddl_tables: set[str] = set()
 
     def execute(self) -> list[StepExecutionResult]:
         logging.info(f"Pipeline initialized with config: {self.config.name}, version: {self.config.version}")
@@ -163,17 +166,15 @@ class PipelineClass:
         logging.info(f"Executing DDL for table '{step.name}'")
 
         try:
-            # TODO: Handle schema evolution
-            # Current implementation just checks for table existence;
-            # mode logic becomes irrelevant for ddl step.
+            # Always DROP + recreate so declared types apply on same-day reruns.
+            # MSSQL DDL uses CREATE TABLE IF NOT EXISTS; Oracle/Teradata use CREATE TABLE.
             with duckdb.connect(self._db_path) as conn:
                 conn.begin()
-                if not self._table_exists(conn, step.name):
-                    conn.execute(ddl)
-                    conn.commit()
-                    logging.debug(f"Created new table '{step.name}'")
-                else:
-                    logging.debug(f"Table '{step.name}' already exists, skipping DDL execution")
+                conn.execute(f"DROP TABLE IF EXISTS {step.name}")
+                conn.execute(ddl)
+                conn.commit()
+                logging.debug(f"Created table '{step.name}'")
+            self._ddl_tables.add(step.name)
         except Exception as e:
             logging.error(f"DDL execution failed: {str(e)}")
             raise RuntimeError(f"DDL execution failed: {str(e)}") from e
@@ -244,28 +245,28 @@ class PipelineClass:
             # Note: step_name is validated to be SQL-safe by Step.__post_init__
             table_exists = self._table_exists(conn, step_name)
             conn.begin()
-            if table_exists and mode == 'overwrite':
-                # Table exists and overwrite mode: Truncate then insert within a transaction to preserve existing DDL schema
-                _result_frame = result.to_df()
-                # Note: step_name is validated to be SQL-safe by Step.__post_init__
-                logging.debug(f"Overwriting existing table '{step_name}'")
-                conn.execute(f"TRUNCATE {step_name}")
-                conn.execute(f"INSERT INTO {step_name} SELECT * FROM _result_frame")
-            else:
-                if table_exists:
-                    # Table exists and append mode: insert into existing table (DuckDB handles type conversion)
-                    _result_frame = result.to_df()
-                    # Note: step_name is validated to be SQL-safe by Step.__post_init__
-                    statement = f"INSERT INTO {step_name} SELECT * FROM _result_frame"
-                    logging.debug(f"Appending to existing table '{step_name}'")
-                else:
-                    # Table doesn't exist: create table with native types from query result
-                    # Use DDL steps for explicit type control when needed
-                    _result_frame = result.to_df()
-                    # Note: step_name is validated to be SQL-safe by Step.__post_init__
-                    statement = f"CREATE TABLE {step_name} AS SELECT * FROM _result_frame"
-                    logging.debug(f"Creating new table '{step_name}' with native types")
+            _result_frame = result.to_df()
 
+            if mode == 'overwrite':
+                if step_name in self._ddl_tables:
+                    # DDL step just recreated an empty typed table; insert into it.
+                    logging.debug(f"Inserting into DDL-owned table '{step_name}'")
+                    conn.execute(f"INSERT INTO {step_name} SELECT * FROM _result_frame")
+                else:
+                    # Replace the relation so types follow this run's data, not a prior CTAS.
+                    logging.debug(f"Replacing table '{step_name}' via DROP + CREATE AS SELECT")
+                    conn.execute(f"DROP TABLE IF EXISTS {step_name}")
+                    conn.execute(f"CREATE TABLE {step_name} AS SELECT * FROM _result_frame")
+            elif table_exists:
+                # Append mode: insert into existing table (DuckDB handles type conversion)
+                statement = f"INSERT INTO {step_name} SELECT * FROM _result_frame"
+                logging.debug(f"Appending to existing table '{step_name}'")
+                logging.debug(f"Executing: {statement}")
+                conn.execute(statement)
+            else:
+                # Table doesn't exist: create table with native types from query result
+                statement = f"CREATE TABLE {step_name} AS SELECT * FROM _result_frame"
+                logging.debug(f"Creating new table '{step_name}' with native types")
                 logging.debug(f"Executing: {statement}")
                 conn.execute(statement)
 

--- a/src/databricks/labs/lakebridge/resources/assessments/common/duckdb_helpers.py
+++ b/src/databricks/labs/lakebridge/resources/assessments/common/duckdb_helpers.py
@@ -68,17 +68,16 @@ def _save_overwrite(
     table_name: str,
     schema: str | None,
 ) -> None:
-    """Replace the contents of ``table_name`` with ``df``.
+    """Replace ``table_name`` with ``df`` (definition and data).
 
     - ``schema`` provided: ``DROP`` + ``CREATE TABLE (...schema...)`` + ``INSERT``
       (the ``INSERT`` is skipped when ``df`` is empty).
-    - ``schema`` omitted, table exists: ``TRUNCATE`` + ``INSERT``. This
-      preserves any DDL-declared column types from a prior run.
-    - ``schema`` omitted, table missing: ``CREATE TABLE AS SELECT *`` from
-      ``df`` (with ``LIMIT 0`` when ``df`` is empty so the columns still land).
-    - ``schema`` omitted, table missing, and ``df`` has no columns: warn and
-      skip. There is nothing we can do without either a schema or column
-      metadata from the DataFrame.
+    - ``schema`` omitted: ``DROP`` + ``CREATE TABLE AS SELECT *`` from ``df``
+      (with ``LIMIT 0`` when ``df`` is empty so the columns still land). Types
+      always follow this write's data, not a prior run's inferred schema.
+    - ``schema`` omitted and ``df`` has no columns: ``DROP`` the table if it
+      exists; otherwise warn and skip. There is nothing we can do without
+      either a schema or column metadata from the DataFrame.
     """
     table_exists = _table_exists(conn, table_name)
 
@@ -92,7 +91,7 @@ def _save_overwrite(
 
     if len(df.columns) == 0:
         if table_exists:
-            conn.execute(f"TRUNCATE {table_name}")
+            conn.execute(f"DROP TABLE IF EXISTS {table_name}")
         else:
             logger.warning(
                 "Cannot create table '%s': empty DataFrame with no columns and no schema provided.",
@@ -101,13 +100,7 @@ def _save_overwrite(
         return
 
     conn.register("_lakebridge_df", df)
-
-    if table_exists:
-        conn.execute(f"TRUNCATE {table_name}")
-        if not df.empty:
-            conn.execute(f"INSERT INTO {table_name} SELECT * FROM _lakebridge_df")
-        return
-
+    conn.execute(f"DROP TABLE IF EXISTS {table_name}")
     limit_clause = " LIMIT 0" if df.empty else ""
     conn.execute(f"CREATE TABLE {table_name} AS SELECT * FROM _lakebridge_df{limit_clause}")
 

--- a/src/databricks/labs/lakebridge/resources/assessments/common/duckdb_helpers.py
+++ b/src/databricks/labs/lakebridge/resources/assessments/common/duckdb_helpers.py
@@ -68,17 +68,7 @@ def _save_overwrite(
     table_name: str,
     schema: str | None,
 ) -> None:
-    """Replace ``table_name`` with ``df`` (definition and data).
-
-    - ``schema`` provided: ``DROP`` + ``CREATE TABLE (...schema...)`` + ``INSERT``
-      (the ``INSERT`` is skipped when ``df`` is empty).
-    - ``schema`` omitted: ``DROP`` + ``CREATE TABLE AS SELECT *`` from ``df``
-      (with ``LIMIT 0`` when ``df`` is empty so the columns still land). Types
-      always follow this write's data, not a prior run's inferred schema.
-    - ``schema`` omitted and ``df`` has no columns: ``DROP`` the table if it
-      exists; otherwise warn and skip. There is nothing we can do without
-      either a schema or column metadata from the DataFrame.
-    """
+    """Replace ``table_name`` with ``df`` (definition and data)."""
     table_exists = _table_exists(conn, table_name)
 
     if schema is not None:

--- a/tests/unit/assessment/test_duckdb_helpers.py
+++ b/tests/unit/assessment/test_duckdb_helpers.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from decimal import Decimal
 from pathlib import Path
 
 import duckdb
@@ -74,15 +75,15 @@ def test_overwrite_zero_column_dataframe_skips_without_error(tmp_path: Path) -> 
     assert "workspace_sql_pools" not in tables
 
 
-def test_overwrite_zero_column_dataframe_truncates_existing_table(tmp_path: Path) -> None:
+def test_overwrite_zero_column_dataframe_drops_existing_table(tmp_path: Path) -> None:
     db_path = str(tmp_path / "t.duckdb")
     save_to_duckdb(pd.DataFrame({"id": [1]}), "t1", db_path)
 
     save_to_duckdb(pd.DataFrame(), "t1", db_path)
 
-    out = _read_table(db_path, "t1")
-    assert out.empty
-    assert list(out.columns) == ["id"]
+    with duckdb.connect(db_path) as conn:
+        tables = conn.execute("SHOW TABLES").fetchdf()["name"].tolist()
+    assert "t1" not in tables
 
 
 def test_overwrite_empty_dataframe_with_schema_creates_empty_table(tmp_path: Path) -> None:
@@ -145,19 +146,24 @@ def test_append_with_explicit_schema_survives_dtype_drift(tmp_path: Path) -> Non
     assert out["login_time"].tolist() == [None, None, "2025-01-01", "2025-01-02"]
 
 
-def test_overwrite_without_schema_truncates_when_table_exists(tmp_path: Path) -> None:
-    """Existing DDL-declared column types should survive an overwrite without ``schema``."""
+def test_overwrite_without_schema_replaces_table_and_types(tmp_path: Path) -> None:
+    """Overwrite replaces the relation so types follow the latest data, not a prior CTAS.
+
+    Guards the Redshift-style failure: a first write of tiny Decimal values freezes a
+    narrow DECIMAL(p,s); a same-day overwrite with larger values must succeed.
+    """
     db_path = str(tmp_path / "t.duckdb")
-    with duckdb.connect(db_path) as conn:
-        conn.execute("CREATE TABLE t1 (id BIGINT, label VARCHAR)")
-        conn.execute("INSERT INTO t1 VALUES (1, 'old')")
+    save_to_duckdb(pd.DataFrame({"sum_cpu_time": [Decimal("0.00001234")]}), "t1", db_path)
 
-    save_to_duckdb(pd.DataFrame({"id": [2], "label": ["new"]}), "t1", db_path)
+    types_after_first = _column_types(db_path, "t1")
+    assert "DECIMAL" in types_after_first["sum_cpu_time"]
 
-    types = _column_types(db_path, "t1")
-    assert types == {"id": "BIGINT", "label": "VARCHAR"}
+    save_to_duckdb(pd.DataFrame({"sum_cpu_time": [Decimal("648")]}), "t1", db_path)
+
     out = _read_table(db_path, "t1")
-    assert out["label"].tolist() == ["new"]
+    assert out["sum_cpu_time"].tolist() == [Decimal("648")]
+    types_after_second = _column_types(db_path, "t1")
+    assert types_after_second["sum_cpu_time"] != types_after_first["sum_cpu_time"]
 
 
 def test_invalid_mode_raises(tmp_path: Path) -> None:


### PR DESCRIPTION
### Issue

Profiler `overwrite` mode replaced rows with `TRUNCATE` + `INSERT` while retaining the existing DuckDB table definition. For tables created through inferred schemas, a first run could persist a narrow type such as `DECIMAL(10,8)`. A same-day rerun with larger values then failed during insertion because the stale schema was reused.

### Solution

- Replace inferred-schema tables with `DROP` + `CREATE TABLE AS SELECT` on overwrite so both the definition and data reflect the current run.
- Recreate DDL-owned tables before loading them so explicitly declared types remain authoritative.
- Align the Python profiler DuckDB helper with the same replace-table semantics.
- Update the existing overwrite tests to cover schema replacement and narrow-to-wide Decimal values.

Tests: `.venv/bin/python -m pytest tests/unit/assessment/test_duckdb_helpers.py -q --tb=short` (13 passed)

### Follow-up

We need to consolidate profiler writes behind a single API. `_save_overwrite`, `save_to_duckdb`, and `_save_to_db` currently provide overlapping write paths and can drift in behavior. A separate issue will be created to track that consolidation.