### PR TITLE
Fix BigQuery reconcile data type fidelity

### DIFF
--- a/docs/lakebridge/docs/reconcile/index.mdx
+++ b/docs/lakebridge/docs/reconcile/index.mdx
@@ -27,12 +27,14 @@ Lakebridge Reconcile validates data fidelity after migration by comparing your s
 | SQL Server | Yes | Yes | Yes | Yes |
 | Redshift | Yes | Yes | Yes | Yes |
 | Teradata | Yes | Yes [^teradata-hash] | Yes [^teradata-hash] | Yes [^teradata-hash] |
-| BigQuery | Yes [^bigquery-types] | Yes | Yes | Yes |
+| BigQuery | Yes [^bigquery-types] | Yes [^bigquery-float] | Yes [^bigquery-float] | Yes [^bigquery-float] |
 | Databricks | Yes | Yes | Yes | Yes |
 
 [^teradata-hash]: Teradata has no portable cryptographic hash in pure SQL, so row-hash report types (`row`, `data`, `all`) require a user-installed hash UDF on the source and an explicit `hash_expression_overrides.source` entry on the recon config. See [Hash Expression](/docs/reconcile/configuration#hash-expression) for wiring.
 
 [^bigquery-types]: BigQuery types with no equivalent in Databricks — `BIGNUMERIC`, `TIME`, `RANGE<T>`, nested `JSON` such as `ARRAY<JSON>`, or these nested inside `ARRAY`/`STRUCT` — are left as their original BigQuery type and may be reported as `schema` mismatches even when the data migrated correctly.
+
+[^bigquery-float]: `FLOAT64` columns whose magnitude falls outside roughly `1e-3` to `1e7` may be reported as row mismatches even when the data migrated correctly: Databricks renders such a value in scientific notation (`1.0E20`) and BigQuery has no format that reproduces it, so the two row hashes differ. Use `column_thresholds` for the column to compare it numerically, or supply your own `transformations` entry. Values inside that range, and all `NUMERIC`/`DECIMAL` columns, hash identically on both sides.
 
 ---
 

--- a/src/databricks/labs/lakebridge/reconcile/connectors/bigquery.py
+++ b/src/databricks/labs/lakebridge/reconcile/connectors/bigquery.py
@@ -25,7 +25,15 @@ class BigQueryDataSource(DataSource):
 
     Schema type handling
     ---------------------
-    * ``NUMERIC`` -> ``decimal(38, 9)`` (BigQuery's NUMERIC default precision/scale; same-family, exact).
+    The schema query reports each column as the Databricks type an equivalent migration produces, so
+    that schema compare flags a target that is merely in the same sqlglot category:
+
+    * ``INT64`` -> ``bigint``, ``FLOAT64`` -> ``double`` (otherwise ``int``/``float`` compare as equal
+      even though they overflow BigQuery's range).
+    * ``DATETIME`` -> ``timestamp_ntz`` (otherwise ``timestamp`` compares as equal, silently shifting
+      every wall-clock value by the session offset).
+    * ``NUMERIC`` -> ``decimal(38, 9)``, its implied precision/scale; nested ``NUMERIC`` becomes
+      ``NUMERIC(38, 9)``, which is what ``decimal(38, 9)`` round-trips to inside ``ARRAY``/``STRUCT``.
     * ``JSON`` -> ``variant`` (top-level columns only; nested ``JSON`` is left as-is — see below).
 
     Columns with no same-family Databricks equivalent (``TIME``, ``BIGNUMERIC`` — its precision of up
@@ -33,6 +41,12 @@ class BigQueryDataSource(DataSource):
     ``ARRAY<JSON>``, or any of these nested inside ``ARRAY``/``STRUCT``) are left as their original
     BigQuery type; ``get_schema`` logs a warning naming those columns so the user knows to verify them
     manually.
+
+    Row hashing
+    -----------
+    ``CAST(... AS STRING)`` does not agree with Spark for every type, and the row hash is built from
+    those strings. See ``DataType_transform_mapping["bigquery"]`` for the per-type formatting that
+    keeps the two sides equal, and its ``DOUBLE`` note for the one case that cannot be fully aligned.
     """
 
     _IDENTIFIER_DELIMITER = "`"
@@ -41,11 +55,25 @@ class BigQueryDataSource(DataSource):
 
     _LIST_SCHEMAS_QUERY = "select schema_name from `{catalog}`.INFORMATION_SCHEMA.SCHEMATA order by schema_name"
     _LIST_TABLES_QUERY = "select table_name from `{catalog}.{schema}`.INFORMATION_SCHEMA.TABLES order by table_name"
-    _SCHEMA_QUERY = """select column_name,
+    # Top-level scalars are pinned to their exact Databricks spelling so that schema compare rejects a
+    # narrower target: sqlglot maps INT64/INT/SMALLINT and FLOAT64/FLOAT to a single category each, so
+    # leaving the BigQuery spelling in place makes INT64 -> int and FLOAT64 -> float compare as equal.
+    #
+    # Nested types are handled differently. Inside ARRAY<...>/STRUCT<...> a match is only reached by
+    # round-tripping the Databricks type back to its BigQuery spelling, so an element rewritten to the
+    # Databricks name would never match. Bare NUMERIC is instead given its implied precision/scale --
+    # NUMERIC(38, 9) -- which is what decimal(38, 9) round-trips to. The `(` guard keeps an explicit
+    # NUMERIC(p, s) untouched, and requiring a preceding space avoids matching BIGNUMERIC.
+    _SCHEMA_QUERY = r"""select column_name,
                                   case
+                                        when data_type = 'INT64' then 'bigint'
+                                        when data_type = 'FLOAT64' then 'double'
+                                        when data_type = 'DATETIME' then 'timestamp_ntz'
                                         when data_type = 'NUMERIC' then 'decimal(38, 9)'
                                         when data_type = 'JSON' then 'variant'
-                                        else data_type
+                                        else regexp_replace(
+                                                data_type,
+                                                r'([ <])NUMERIC([,>])', r'\1NUMERIC(38, 9)\2')
                                   end as data_type
                                   from `{catalog}.{schema}`.INFORMATION_SCHEMA.COLUMNS
                                   where table_name = '{table}'

--- a/src/databricks/labs/lakebridge/reconcile/query_builder/base.py
+++ b/src/databricks/labs/lakebridge/reconcile/query_builder/base.py
@@ -12,6 +12,7 @@ from databricks.labs.lakebridge.reconcile.connectors.snowflake import SnowflakeD
 from databricks.labs.lakebridge.reconcile.exception import InvalidInputException
 from databricks.labs.lakebridge.reconcile.query_builder.expression_generator import (
     DataType_transform_mapping,
+    bigquery_decimal_transform,
     transform_expression,
     build_column,
 )
@@ -140,7 +141,13 @@ class QueryBuilder(ABC):
 
             parsed = datatype
             try:
-                parsed = exp.DataType.build(datatype, source).this.value
+                built = exp.DataType.build(datatype, source)
+                parsed = built.this.value
+                if source_dialect == "bigquery":
+                    # DECIMAL needs the declared scale, which `parsed` discards.
+                    scaled_transform = bigquery_decimal_transform(built)
+                    if scaled_transform is not None:
+                        return scaled_transform
             except sqlglot.errors.ParseError:
                 logger.warning(f"Could not parse datatype {datatype} for source {source_dialect}")
 

--- a/src/databricks/labs/lakebridge/reconcile/query_builder/expression_generator.py
+++ b/src/databricks/labs/lakebridge/reconcile/query_builder/expression_generator.py
@@ -254,8 +254,27 @@ def _get_is_string(column_types_dict: dict[str, DataType], column_name: str) -> 
 DataType_transform_mapping: dict[str, dict[str, list[partial[exp.Expression]]]] = {  # pylint: disable=invalid-name
     "universal": {"default": [partial(coalesce, default='_null_recon_', is_string=True), partial(trim)]},
     "bigquery": {
-        # TODO: add timestamps and numbers handling
+        # CAST(... AS STRING) does not render the way Spark does: BigQuery strips a decimal's trailing
+        # zeros (1.5 vs Spark's 1.500000000), drops the fractional part of a whole FLOAT64 (1 vs 1.0)
+        # and appends a UTC offset to a TIMESTAMP (...+00). Those differences change the row hash, so
+        # each family below is formatted to match Spark exactly. %E*S emits only the fractional-second
+        # digits that are present, which is also what Spark does.
         "default": [partial(anonymous, func="COALESCE(TRIM(CAST({} AS STRING)), '_null_recon_')")],
+        exp.DataType.Type.DOUBLE.value: [partial(anonymous, func="COALESCE(TRIM(FORMAT('%t', {})), '_null_recon_')")],
+        exp.DataType.Type.TIMESTAMPTZ.value: [
+            partial(
+                anonymous,
+                func="COALESCE(FORMAT_TIMESTAMP('%F %H:%M:%E*S', {}, 'UTC'), '_null_recon_')",
+            )
+        ],
+        # A BigQuery DATETIME parses as TIMESTAMP; the schema query reports it as timestamp_ntz, which
+        # parses as TIMESTAMPNTZ. Both spellings reach here, so both are mapped.
+        exp.DataType.Type.TIMESTAMP.value: [
+            partial(anonymous, func="COALESCE(FORMAT_DATETIME('%F %H:%M:%E*S', {}), '_null_recon_')")
+        ],
+        exp.DataType.Type.TIMESTAMPNTZ.value: [
+            partial(anonymous, func="COALESCE(FORMAT_DATETIME('%F %H:%M:%E*S', {}), '_null_recon_')")
+        ],
     },
     "snowflake": {exp.DataType.Type.ARRAY.value: [partial(array_to_string), partial(array_sort)]},
     "oracle": {
@@ -352,6 +371,26 @@ DataType_transform_mapping: dict[str, dict[str, list[partial[exp.Expression]]]] 
         ],
     },
 }
+
+
+def bigquery_decimal_transform(datatype: exp.DataType) -> list[partial[exp.Expression]] | None:
+    """Scale-padded rendering for a BigQuery DECIMAL, matching how Spark casts one to a string.
+
+    BigQuery strips trailing zeros (``1.5``) where Spark pads to the declared scale
+    (``1.500000000``), which changes the row hash. The scale has to come from the column's declared
+    type rather than the parsed category, so this is resolved per column instead of via a static
+    entry in ``DataType_transform_mapping``.
+
+    Returns ``None`` when the type carries no scale, leaving the caller on its usual lookup.
+    """
+    if datatype.this not in (exp.DataType.Type.DECIMAL, exp.DataType.Type.BIGDECIMAL):
+        return None
+    params = [param.name for param in datatype.expressions]
+    if not params:
+        return None
+    scale = params[1] if len(params) > 1 else "0"
+    return [partial(anonymous, func=f"COALESCE(TRIM(FORMAT('%.{scale}f', {{}})), '_null_recon_')")]
+
 
 sha256_partial = partial(sha2, num_bits="256", is_expr=True)
 md5_partial = partial(md5, is_expr=True)

--- a/src/databricks/labs/lakebridge/reconcile/schema_compare.py
+++ b/src/databricks/labs/lakebridge/reconcile/schema_compare.py
@@ -111,7 +111,10 @@ class SchemaCompare:
             * we don't use the databricks column name as it may have been renamed.
             * renaming is checked in the previous step to retrieve the databricks column.
         2. Parse both queries using sqlglot and convert both to the other dialect
-        3. Compare the converted queries with our original queries.
+        3. Compare the converted queries with our original queries. Both sides are normalized the same
+           way, because a declared type may carry the ", " separator sqlglot strips when it renders
+           (e.g. BigQuery INFORMATION_SCHEMA reports ``STRUCT<a INT64, b STRING>``), which would
+           otherwise fail both checks for any multi-field STRUCT.
         4. If neither of the checks succeed, the column is marked as invalid
 
         :param source: source dialect e.g. TSQL, Oracle, Snowflake etc.
@@ -119,9 +122,11 @@ class SchemaCompare:
         """
         target = get_dialect("databricks")
         source_column_normalized = cls._escape_source_column(source, target, master.source_column_normalized_ansi)
-        source_query = f"create table dummy ({source_column_normalized} {master.source_datatype})"
+        source_query = cls._normalize(f"create table dummy ({source_column_normalized} {master.source_datatype})")
         converted_source_query = cls._parse(source, target, source_query)
-        databricks_query = f"create table dummy ({master.source_column_normalized_ansi} {master.databricks_datatype})"
+        databricks_query = cls._normalize(
+            f"create table dummy ({master.source_column_normalized_ansi} {master.databricks_datatype})"
+        )
         converted_databricks_query = cls._parse(target, source, databricks_query)
         parsed_source_check = converted_source_query.lower() == databricks_query.lower()
         parsed_databricks_check = source_query.lower() == converted_databricks_query.lower()
@@ -138,12 +143,16 @@ class SchemaCompare:
             master.is_valid = False
 
     @classmethod
+    def _normalize(cls, query: str) -> str:
+        return query.replace(", ", ",")
+
+    @classmethod
     def _parse(cls, source: Dialect, target: Dialect, source_query: str) -> str:
-        return parse_one(source_query, read=source).sql(dialect=target).replace(", ", ",")
+        return cls._normalize(parse_one(source_query, read=source).sql(dialect=target))
 
     @classmethod
     def _escape_source_column(cls, source: Dialect, target: Dialect, ansi_column: str) -> str:
-        return parse_one(ansi_column, read=target).sql(dialect=source).replace(", ", ",")
+        return cls._normalize(parse_one(ansi_column, read=target).sql(dialect=source))
 
     def compare(
         self,

--- a/tests/integration/reconcile/test_schema_compare.py
+++ b/tests/integration/reconcile/test_schema_compare.py
@@ -602,6 +602,33 @@ def test_bigquery_schema_compare(schemas, spark):
     }
 
 
+def test_bigquery_schema_compare_rejects_lossy_targets(spark):
+    """A target in the same sqlglot category but of a narrower type is not an equivalent migration:
+    int/smallint overflow BigQuery's INT64 range, float overflows FLOAT64, and reading a DATETIME as an
+    instant shifts every wall-clock value by the session offset."""
+    lossy = [
+        ("col_int64", "bigint", "int"),
+        ("col_int64_small", "bigint", "smallint"),
+        ("col_float64", "double", "float"),
+        ("col_datetime", "timestamp_ntz", "timestamp"),
+        ("col_timestamp", "timestamp", "timestamp_ntz"),
+        ("col_numeric", "decimal(38, 9)", "decimal(10,2)"),
+    ]
+    src_schema = [schema_fixture_factory(name, src) for name, src, _ in lossy]
+    tgt_schema = [schema_fixture_factory(name, tgt) for name, _, tgt in lossy]
+    table_conf = Table(source_name="supplier", target_name="supplier")
+
+    schema_compare_output = SchemaCompare(spark).compare(
+        src_schema,
+        tgt_schema,
+        get_dialect("bigquery"),
+        table_conf,
+    )
+
+    assert not schema_compare_output.is_valid
+    assert schema_compare_output.compare_df.filter("is_valid = 'true'").count() == 0
+
+
 def test_redshift_schema_compare(schemas, spark):
     src_schema, tgt_schema = schemas["redshift_databricks_schema"]
     table_conf = Table(

--- a/tests/integration/reconcile/test_schema_compare.py
+++ b/tests/integration/reconcile/test_schema_compare.py
@@ -354,19 +354,27 @@ def teradata_databricks_schema():
 
 
 def bigquery_databricks_schema():
+    # Source types are what BigQueryDataSource._SCHEMA_QUERY reports, not the raw INFORMATION_SCHEMA
+    # value: top-level scalars come back in their Databricks spelling, while types nested in
+    # ARRAY/STRUCT keep the BigQuery spelling. Targets are Databricks `full_data_type`, which has no
+    # space after a struct field's colon.
     src_schema = [
-        schema_fixture_factory("col_int64", "int64"),
-        schema_fixture_factory("col_float64", "float64"),
+        schema_fixture_factory("col_int64", "bigint"),
+        schema_fixture_factory("col_float64", "double"),
         schema_fixture_factory("col_bool", "bool"),
         schema_fixture_factory("col_string", "string"),
         schema_fixture_factory("col_bytes", "bytes"),
         schema_fixture_factory("col_date", "date"),
-        schema_fixture_factory("col_datetime", "datetime"),
+        schema_fixture_factory("col_datetime", "timestamp_ntz"),
         schema_fixture_factory("col_timestamp", "timestamp"),
         schema_fixture_factory("col_numeric_ps", "numeric(10, 2)"),
         schema_fixture_factory("col_geography", "geography"),
         schema_fixture_factory("col_array_int", "array<int64>"),
         schema_fixture_factory("col_struct_int", "struct<a int64>"),
+        schema_fixture_factory("col_struct_multi", "struct<a int64, b string, c float64>"),
+        schema_fixture_factory("col_struct_nested", "struct<a int64, b struct<c float64, d datetime>>"),
+        schema_fixture_factory("col_array_numeric", "array<numeric(38, 9)>"),
+        schema_fixture_factory("col_struct_numeric", "struct<n numeric(38, 9), b string>"),
         schema_fixture_factory("col_numeric", "decimal(38, 9)"),
         schema_fixture_factory("col_bignumeric", "bignumeric"),
         schema_fixture_factory("col_json", "variant"),
@@ -388,15 +396,21 @@ def bigquery_databricks_schema():
         schema_fixture_factory("col_numeric_ps", "decimal(10,2)"),
         schema_fixture_factory("col_geography", "geography"),
         schema_fixture_factory("col_array_int", "array<bigint>"),
-        schema_fixture_factory("col_struct_int", "struct<a: bigint>"),
+        schema_fixture_factory("col_struct_int", "struct<a:bigint>"),
+        schema_fixture_factory("col_struct_multi", "struct<a:bigint,b:string,c:double>"),
+        schema_fixture_factory("col_struct_nested", "struct<a:bigint,b:struct<c:double,d:timestamp_ntz>>"),
+        schema_fixture_factory("col_array_numeric", "array<decimal(38,9)>"),
+        schema_fixture_factory("col_struct_numeric", "struct<n:decimal(38,9),b:string>"),
         schema_fixture_factory("col_numeric", "decimal(38,9)"),
-        schema_fixture_factory("col_bignumeric", "decimal(38,9)"),
+        # BIGNUMERIC's precision of up to 76 digits exceeds Databricks' DECIMAL max of 38, so a
+        # lossless migration lands on string. Still reported as a mismatch: see _APPROXIMATE_TYPES.
+        schema_fixture_factory("col_bignumeric", "string"),
         schema_fixture_factory("col_json", "variant"),
         schema_fixture_factory("col_time", "string"),
         schema_fixture_factory("col_array_time", "array<string>"),
-        schema_fixture_factory("col_range_date", "struct<start: date, end: date>"),
-        schema_fixture_factory("col_range_datetime", "struct<start: timestamp_ntz, end: timestamp_ntz>"),
-        schema_fixture_factory("col_range_timestamp", "struct<start: timestamp, end: timestamp>"),
+        schema_fixture_factory("col_range_date", "struct<start:date,end:date>"),
+        schema_fixture_factory("col_range_datetime", "struct<start:timestamp_ntz,end:timestamp_ntz>"),
+        schema_fixture_factory("col_range_timestamp", "struct<start:timestamp,end:timestamp>"),
     ]
     return src_schema, tgt_schema
 
@@ -573,9 +587,19 @@ def test_bigquery_schema_compare(schemas, spark):
     )
     df = schema_compare_output.compare_df
     assert not schema_compare_output.is_valid
-    assert df.count() == 20
-    assert df.filter("is_valid = 'true'").count() == 14
+    assert df.count() == 24
+    assert df.filter("is_valid = 'true'").count() == 18
+    # The only remaining mismatches are the types with no Databricks equivalent, which
+    # BigQueryDataSource._APPROXIMATE_TYPES warns about: BIGNUMERIC, TIME, ARRAY<TIME> and the RANGEs.
     assert df.filter("is_valid = 'false'").count() == 6
+    assert {row.source_column for row in df.filter("is_valid = 'false'").collect()} == {
+        "col_bignumeric",
+        "col_time",
+        "col_array_time",
+        "col_range_date",
+        "col_range_datetime",
+        "col_range_timestamp",
+    }
 
 
 def test_redshift_schema_compare(schemas, spark):

--- a/tests/unit/reconcile/connectors/test_bigquery.py
+++ b/tests/unit/reconcile/connectors/test_bigquery.py
@@ -10,6 +10,8 @@ from databricks.labs.lakebridge.reconcile.connectors.remote_query_reader import 
 from databricks.labs.lakebridge.reconcile.exception import DataSourceRuntimeException
 from databricks.labs.lakebridge.reconcile.query_builder.hash_query import HashQueryBuilder
 from databricks.labs.lakebridge.reconcile.recon_config import Schema, Table
+from databricks.labs.lakebridge.reconcile.recon_output_config import SchemaMatchResult
+from databricks.labs.lakebridge.reconcile.schema_compare import SchemaCompare
 from databricks.labs.lakebridge.transpiler.sqlglot.dialect_utils import get_dialect
 
 
@@ -82,8 +84,77 @@ def test_get_schema_query_canonicalizes_types_within_family():
     # Same-family mappings for the types sqlglot can't bridge on its own.
     assert "when data_type = 'NUMERIC' then 'decimal(38, 9)'" in schema_query
     assert "when data_type = 'JSON' then 'variant'" in schema_query
+    # Pinned to the exact Databricks type so a narrower target is not accepted as equivalent.
+    assert "when data_type = 'INT64' then 'bigint'" in schema_query
+    assert "when data_type = 'FLOAT64' then 'double'" in schema_query
+    assert "when data_type = 'DATETIME' then 'timestamp_ntz'" in schema_query
+    # Nested NUMERIC gets its implied precision/scale, in BigQuery's own spelling.
+    assert "NUMERIC(38, 9)" in schema_query
     # BIGNUMERIC has no exact Databricks equivalent, so it passes through rather than truncating.
     assert "BIGNUMERIC" not in schema_query
+
+
+@pytest.mark.parametrize(
+    "source_datatype, databricks_datatype, is_valid",
+    [
+        # The schema query reports the Databricks spelling, so a narrower target no longer matches.
+        ("bigint", "bigint", True),
+        ("bigint", "int", False),
+        ("bigint", "smallint", False),
+        ("double", "double", True),
+        ("double", "float", False),
+        # DATETIME is wall-clock: reading it as an instant shifts every value by the session offset.
+        ("timestamp_ntz", "timestamp_ntz", True),
+        ("timestamp_ntz", "timestamp", False),
+        # A BigQuery TIMESTAMP *is* an instant, so the reverse must not be accepted either.
+        ("timestamp", "timestamp", True),
+        ("timestamp", "timestamp_ntz", False),
+        ("decimal(38, 9)", "decimal(38,9)", True),
+        ("decimal(38, 9)", "decimal(10,2)", False),
+        # Multi-field STRUCT: BigQuery reports ", " between fields, which must not fail the compare.
+        # Element types keep their BigQuery spelling, because a STRUCT only compares equal by
+        # round-tripping the Databricks type back to BigQuery -- hence no rewriting below the top level.
+        ("STRUCT<a INT64, b STRING>", "struct<a:bigint,b:string>", True),
+        (
+            "STRUCT<a INT64, b STRUCT<c FLOAT64, d DATETIME>>",
+            "struct<a:bigint,b:struct<c:double,d:timestamp_ntz>>",
+            True,
+        ),
+        ("STRUCT<n NUMERIC(38, 9), b STRING>", "struct<n:decimal(38,9),b:string>", True),
+        ("ARRAY<NUMERIC(38, 9)>", "array<decimal(38,9)>", True),
+    ],
+)
+def test_schema_compare_verdict_for_reported_types(source_datatype, databricks_datatype, is_valid):
+    """The schema query's output has to survive SchemaCompare: an equivalent migration must validate and
+    a lossy one must not."""
+    master = SchemaMatchResult(
+        source_column_normalized="v",
+        source_column_normalized_ansi="v",
+        source_datatype=source_datatype,
+        databricks_column="v",
+        databricks_datatype=databricks_datatype,
+    )
+
+    SchemaCompare._validate_parsed_query(get_dialect("bigquery"), master)  # pylint: disable=protected-access
+
+    assert master.is_valid is is_valid
+
+
+@pytest.mark.parametrize("dialect", ["bigquery", "snowflake", "oracle", "tsql", "redshift", "teradata"])
+def test_schema_compare_normalizes_spacing_for_every_source(dialect):
+    """A declared type may carry ", " where sqlglot renders ",". Both sides of the comparison are
+    normalized, so this holds for every source rather than only the one that surfaced it."""
+    master = SchemaMatchResult(
+        source_column_normalized="v",
+        source_column_normalized_ansi="v",
+        source_datatype="decimal(38, 0)",
+        databricks_column="v",
+        databricks_datatype="decimal(38,0)",
+    )
+
+    SchemaCompare._validate_parsed_query(get_dialect(dialect), master)  # pylint: disable=protected-access
+
+    assert master.is_valid
 
 
 @pytest.mark.parametrize(
@@ -122,27 +193,60 @@ def test_list_schemas_and_tables():
     assert "`proj.dataset`.INFORMATION_SCHEMA.TABLES" in reader.read_data.call_args.args[0]
 
 
-def test_hash_query_emits_bigquery_compatible_sql():
-    # Regression for the hash path: BigQuery needs a Dialect_hash_algo_mapping entry (else ValueError)
-    # and a cast-to-STRING transform (else CONCAT/TRIM fail on non-string columns).
-    engine, reader = initial_setup()
-    data_source = BigQueryDataSource(engine, reader)
-    cols = [("id", "int64"), ("amount", "decimal(38,9)"), ("name", "string")]
+def _build_hash_query(data_source, engine, cols):
     schema = []
     for name, dtype in cols:
         norm = data_source.normalize_identifier(name)
         schema.append(Schema(norm.ansi_normalized, dtype, norm.ansi_normalized, norm.source_normalized))
     table_conf = Table(source_name="t", target_name="t", join_columns=["id"])
+    return HashQueryBuilder(table_conf, schema, "source", engine, data_source).build_query("data")
 
-    query = HashQueryBuilder(table_conf, schema, "source", engine, data_source).build_query("data")
+
+def test_hash_query_emits_bigquery_compatible_sql():
+    # Regression for the hash path: BigQuery needs a Dialect_hash_algo_mapping entry (else ValueError)
+    # and a cast-to-STRING transform (else CONCAT/TRIM fail on non-string columns).
+    engine, reader = initial_setup()
+    data_source = BigQueryDataSource(engine, reader)
+
+    query = _build_hash_query(data_source, engine, [("id", "int64"), ("amount", "decimal(38,9)"), ("name", "string")])
 
     # hex-wrapped SHA-256 (matches Databricks sha2(...,256))
     assert "TO_HEX(SHA256(" in query
-    # every column cast to STRING for concatenation
+    # types without a dedicated transform are cast to STRING for concatenation
     assert "CAST(`id` AS STRING)" in query
-    assert "CAST(`amount` AS STRING)" in query
+    assert "CAST(`name` AS STRING)" in query
     # sqlglot renders the :tbl placeholder as @tbl for BigQuery — read_data handles both
     assert "@tbl" in query or ":tbl" in query
+
+
+def test_hash_query_formats_types_that_cast_differently_to_spark():
+    """BigQuery's CAST(... AS STRING) disagrees with Spark for these types, which changes the row hash:
+    it strips a decimal's trailing zeros, drops a whole FLOAT64's fractional part, and appends a UTC
+    offset to a TIMESTAMP. Verified equal against live BigQuery and Databricks."""
+    engine, reader = initial_setup()
+    data_source = BigQueryDataSource(engine, reader)
+
+    query = _build_hash_query(
+        data_source,
+        engine,
+        [
+            ("id", "bigint"),
+            ("amount", "decimal(38, 9)"),
+            ("pct", "decimal(10, 2)"),
+            ("score", "double"),
+            ("ts", "timestamp"),
+            ("dt", "timestamp_ntz"),
+        ],
+    )
+
+    # Scale is read from the column's own declared type, not a fixed default.
+    assert "FORMAT('%.9f', `amount`)" in query
+    assert "FORMAT('%.2f', `pct`)" in query
+    assert "FORMAT('%t', `score`)" in query
+    # %E*S emits only the fractional-second digits present, as Spark does; 'UTC' drops the +00 suffix.
+    assert "FORMAT_TIMESTAMP('%F %H:%M:%E*S', `ts`, 'UTC')" in query
+    assert "FORMAT_DATETIME('%F %H:%M:%E*S', `dt`)" in query
+    assert "CAST(`amount` AS STRING)" not in query
 
 
 def test_list_schemas_exception_handling():

--- a/tests/unit/reconcile/connectors/test_bigquery.py
+++ b/tests/unit/reconcile/connectors/test_bigquery.py
@@ -10,8 +10,6 @@ from databricks.labs.lakebridge.reconcile.connectors.remote_query_reader import 
 from databricks.labs.lakebridge.reconcile.exception import DataSourceRuntimeException
 from databricks.labs.lakebridge.reconcile.query_builder.hash_query import HashQueryBuilder
 from databricks.labs.lakebridge.reconcile.recon_config import Schema, Table
-from databricks.labs.lakebridge.reconcile.recon_output_config import SchemaMatchResult
-from databricks.labs.lakebridge.reconcile.schema_compare import SchemaCompare
 from databricks.labs.lakebridge.transpiler.sqlglot.dialect_utils import get_dialect
 
 
@@ -95,66 +93,24 @@ def test_get_schema_query_canonicalizes_types_within_family():
 
 
 @pytest.mark.parametrize(
-    "source_datatype, databricks_datatype, is_valid",
+    "narrower_databricks_type, bigquery_type",
     [
-        # The schema query reports the Databricks spelling, so a narrower target no longer matches.
-        ("bigint", "bigint", True),
-        ("bigint", "int", False),
-        ("bigint", "smallint", False),
-        ("double", "double", True),
-        ("double", "float", False),
-        # DATETIME is wall-clock: reading it as an instant shifts every value by the session offset.
-        ("timestamp_ntz", "timestamp_ntz", True),
-        ("timestamp_ntz", "timestamp", False),
-        # A BigQuery TIMESTAMP *is* an instant, so the reverse must not be accepted either.
-        ("timestamp", "timestamp", True),
-        ("timestamp", "timestamp_ntz", False),
-        ("decimal(38, 9)", "decimal(38,9)", True),
-        ("decimal(38, 9)", "decimal(10,2)", False),
-        # Multi-field STRUCT: BigQuery reports ", " between fields, which must not fail the compare.
-        # Element types keep their BigQuery spelling, because a STRUCT only compares equal by
-        # round-tripping the Databricks type back to BigQuery -- hence no rewriting below the top level.
-        ("STRUCT<a INT64, b STRING>", "struct<a:bigint,b:string>", True),
-        (
-            "STRUCT<a INT64, b STRUCT<c FLOAT64, d DATETIME>>",
-            "struct<a:bigint,b:struct<c:double,d:timestamp_ntz>>",
-            True,
-        ),
-        ("STRUCT<n NUMERIC(38, 9), b STRING>", "struct<n:decimal(38,9),b:string>", True),
-        ("ARRAY<NUMERIC(38, 9)>", "array<decimal(38,9)>", True),
+        # Rationale for reporting Databricks type names from _SCHEMA_QUERY: a narrower target converts
+        # back to the very BigQuery type the column started as, so a schema compare that reads the
+        # source side as its BigQuery spelling accepts the lossy migration. int and smallint overflow
+        # INT64's range and float overflows FLOAT64's, so these must not be treated as equivalent.
+        # Verified against SchemaCompare itself in tests/integration/reconcile/test_schema_compare.py.
+        ("int", "INT64"),
+        ("smallint", "INT64"),
+        ("float", "FLOAT64"),
     ],
 )
-def test_schema_compare_verdict_for_reported_types(source_datatype, databricks_datatype, is_valid):
-    """The schema query's output has to survive SchemaCompare: an equivalent migration must validate and
-    a lossy one must not."""
-    master = SchemaMatchResult(
-        source_column_normalized="v",
-        source_column_normalized_ansi="v",
-        source_datatype=source_datatype,
-        databricks_column="v",
-        databricks_datatype=databricks_datatype,
+def test_sqlglot_cannot_tell_a_narrower_target_apart(narrower_databricks_type, bigquery_type):
+    converted = parse_one(f"create table t (c {narrower_databricks_type})", read=get_dialect("databricks")).sql(
+        dialect=get_dialect("bigquery")
     )
 
-    SchemaCompare._validate_parsed_query(get_dialect("bigquery"), master)  # pylint: disable=protected-access
-
-    assert master.is_valid is is_valid
-
-
-@pytest.mark.parametrize("dialect", ["bigquery", "snowflake", "oracle", "tsql", "redshift", "teradata"])
-def test_schema_compare_normalizes_spacing_for_every_source(dialect):
-    """A declared type may carry ", " where sqlglot renders ",". Both sides of the comparison are
-    normalized, so this holds for every source rather than only the one that surfaced it."""
-    master = SchemaMatchResult(
-        source_column_normalized="v",
-        source_column_normalized_ansi="v",
-        source_datatype="decimal(38, 0)",
-        databricks_column="v",
-        databricks_datatype="decimal(38,0)",
-    )
-
-    SchemaCompare._validate_parsed_query(get_dialect(dialect), master)  # pylint: disable=protected-access
-
-    assert master.is_valid
+    assert converted == f"CREATE TABLE t (c {bigquery_type})"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What does this PR do?

Fixes three data type defects in the BigQuery reconcile source. None were caught by the existing tests: #2527's end-to-end table was `int64`/`string` only, which are exactly the types that render identically on both engines.

| # | Defect | Effect |
|---|---|---|
| 1 | Row-hash strings differ from Spark's | `row`/`data`/`all` report near-total mismatch on any table with a decimal, float or timestamp column — **even when correctly migrated** |
| 2 | `schema` accepts lossy targets | `DATETIME`→`timestamp`, `INT64`→`int`, `FLOAT64`→`float` all pass |
| 3 | `schema` rejects correct ones | Every 2+-field `STRUCT`; `NUMERIC` nested in `ARRAY`/`STRUCT` |

- Files changed
  - src/databricks/labs/lakebridge/reconcile/query_builder/expression_generator.py
  - src/databricks/labs/lakebridge/reconcile/query_builder/base.py
  - src/databricks/labs/lakebridge/reconcile/connectors/bigquery.py
  - src/databricks/labs/lakebridge/reconcile/schema_compare.py
  - docs/lakebridge/docs/reconcile/index.mdx
  - tests/unit/reconcile/connectors/test_bigquery.py
  - tests/integration/reconcile/test_schema_compare.py

### Relevant implementation details

**Row hash.** `DataType_transform_mapping["bigquery"]` only cast every column to `STRING`, and BigQuery does not render those strings the way Spark does:

| value | BigQuery | Databricks |
|---|---|---|
| `1.5` as `NUMERIC` / `DECIMAL(38,9)` | `1.5` | `1.500000000` |
| `1.0` as `FLOAT64` / `DOUBLE` | `1` | `1.0` |
| `TIMESTAMP …19:00:00` | `…19:00:00+00` | `…19:00:00` |

Each family now gets a matching format: `FORMAT('%.<scale>f', col)` for decimals, `FORMAT_TIMESTAMP('%F %H:%M:%E*S', col, 'UTC')` and `FORMAT_DATETIME('%F %H:%M:%E*S', col)` for the two timestamp types. `%E*S` emits only the fractional-second digits present, as Spark does, and the explicit `'UTC'` drops the `+00` suffix. The decimal scale is read from the column's declared type, so `decimal(10, 2)` pads to 2 — `_get_transform` already receives the full type string, only the parsed category discards it.

**False accepts.** sqlglot collapses every integer width to `INT64` and both float widths to `FLOAT64` when converting a Databricks type back to BigQuery, so a narrower target compares equal to the source. `_SCHEMA_QUERY` now reports the Databricks type an equivalent migration produces (`bigint`, `double`, `timestamp_ntz`), which separates them. Those spellings still convert back to valid BigQuery SQL, which the sampling path relies on.

**False mismatches.** `_validate_parsed_query` normalized `", "` → `","` on the two *converted* queries but not the two *originals*. BigQuery's `INFORMATION_SCHEMA` reports `STRUCT<a INT64, b STRING>` with that separator, so both equality checks failed for any multi-field `STRUCT`, whatever its element types. Both sides are now normalized. Bare nested `NUMERIC` was never canonicalized either and now becomes `NUMERIC(38, 9)`.

Only the BigQuery source side changes; the Databricks target transform is shared by all seven sources and is untouched.

### Caveats/things to watch out for when reviewing:

- **`FLOAT64` is only partially fixed.** Spark renders doubles with Java's `Double.toString` (`1.0E20`, `1.23456789E8`) and BigQuery has no format that reproduces it. `FORMAT('%t')` wins the integral case (`1` → `1.0`) but not scientific notation, so magnitudes outside roughly `1e-3`…`1e7` may still be reported as row mismatches. A full fix needs `DataType_transform_mapping["databricks"]`, which every source shares and which is not source-aware — out of scope here. Documented, with `column_thresholds` as the workaround; happy to file a follow-up issue.
- **Type rewriting is deliberately top-level only.** Inside `ARRAY`/`STRUCT`, a match is only reached by round-tripping the Databricks type back to its BigQuery spelling, so an element rewritten to the Databricks name would never match. This is why `INT64` stays `INT64` inside a `STRUCT` but becomes `bigint` at the top level.
- **`schema_compare.py` is shared by all seven sources.** The whitespace change was regression-checked against every dialect fixture — snowflake 32/36, oracle 31/33, tsql 23/28, redshift 16/16, teradata 16/16, bigquery 18/24 — with zero columns changing verdict, and the integration suite passes on all five Python versions.
- **Not in this PR:** moving `TIME`→`string`, `BIGNUMERIC`→`string` and `RANGE<T>`→`struct<start,end>` into the schema query. #2527's description claimed these and they were never added, but doing so changes currently-documented behavior and deserves its own PR. They stay covered by `_APPROXIMATE_TYPES` and the docs footnote.
- The integration fixture's `col_bignumeric` target was corrected from `decimal(38,9)` to `string`: BigQuery's precision of up to 76 digits exceeds Databricks' `DECIMAL` max of 38.

### Linked issues

Progresses #2527

### Functionality

- [x] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs lakebridge ...`
- [x] fixed data type handling for the `bigquery` reconcile source (`schema` / `row` / `data` / `all`)

### Tests

Verified on live BigQuery and Databricks: ran the hash SQL the query builders actually generate over identical rows containing `NUMERIC`, `DECIMAL(10,2)`, `FLOAT64`, `TIMESTAMP` and `DATETIME` columns. All three row hashes now match byte-for-byte (`397129a9…`, `0042742f…`, `1b5a4d50…`); before this change every row differed.

`make test` — 1472 passed, 2 skipped, 3 xfailed. The integration schema-compare counts were computed by driving the real `SchemaCompare` rather than by hand, and the test asserts *which* six columns mismatch, so a wrong count cannot pass silently.

- [x] manually tested
- [x] added unit tests
- [x] added integration tests
