### PR TITLE
Improved logging for profiler runs.

### DIFF
--- a/src/databricks/labs/lakebridge/assessments/pipeline.py
+++ b/src/databricks/labs/lakebridge/assessments/pipeline.py
@@ -13,7 +13,7 @@ import yaml
 from databricks.labs.blueprint.paths import read_text
 from databricks.labs.lakebridge import __version__ as lakebridge_version
 from databricks.labs.lakebridge.assessments.profiler_config import PipelineConfig, Step
-from databricks.labs.lakebridge.connections.database_manager import DatabaseConnector, FetchResult
+from databricks.labs.lakebridge.connections.database_manager import DatabaseConnector, FetchResult, StreamResult
 from databricks.labs.lakebridge.resources.assessments.common.duckdb_helpers import (
     SaveMode,
     connect_to_profiler_db,
@@ -129,19 +129,84 @@ class PipelineClass:
             logging.error("Database executor is not set.")
             raise RuntimeError("Database executor is not set.")
 
-        logging.info(f"Executing query: {query}")
+        logger.info("%s: Submitting query to source.", step.name)
+        logger.debug("Executing query: %s", query)
+
         if hasattr(self.executor, "stream"):
-            first = True
-            for df in self.executor.stream(query):
+            self._execute_sql_step_stream(step, query)
+            return
+
+        self._execute_sql_step_fetch(step, query)
+
+    def _execute_sql_step_stream(self, step: Step, query: str) -> None:
+        assert self.executor is not None
+        stream = getattr(self.executor, "stream")
+        try:
+            stream_result: StreamResult = stream(query)
+        except ConnectionError as e:
+            logger.info("%s: Query execution failed: %s", step.name, e)
+            raise
+
+        logger.info("%s: Query execution completed successfully.", step.name)
+        first = True
+        chunks_seen = 0
+        try:
+            for i, df in enumerate(stream_result.batches, start=1):
+                chunks_seen = i
+                total = stream_result.total_chunks if stream_result.total_chunks > 0 else i
+                logger.info(
+                    "%s: Fetching and writing results (%d/%d).",
+                    step.name,
+                    i,
+                    total,
+                )
                 if df.empty:
                     continue
                 write_mode: SaveMode = "overwrite" if first and step.mode == "overwrite" else "append"
                 save_to_duckdb(df, step.name, str(self._db_path), mode=write_mode)
                 first = False
+
+            if chunks_seen == 0:
+                logging.warning(
+                    "Query for step '%s' returned 0 chunks. Skipping table creation and data insertion.",
+                    step.name,
+                )
+        except Exception as e:
+            logger.info("%s: Fetching and writing results failed: %s", step.name, e)
+            raise
+        finally:
+            stream_result.close()
+
+    def _execute_sql_step_fetch(self, step: Step, query: str) -> None:
+        assert self.executor is not None
+        fetch_started = False
+
+        def on_executed() -> None:
+            nonlocal fetch_started
+            logger.info("%s: Query execution completed successfully.", step.name)
+            logger.info("%s: Fetching results.", step.name)
+            fetch_started = True
+
+        try:
+            result = self.executor.fetch(query, on_executed=on_executed)
+        except ConnectionError as e:
+            if fetch_started:
+                logger.info("%s: Fetching results failed: %s", step.name, e)
+            else:
+                logger.info("%s: Query execution failed: %s", step.name, e)
+            raise
+
+        if not result.rows:
+            self._save_to_db(result, step.name, step.mode)
             return
 
-        result = self.executor.fetch(query)
-        self._save_to_db(result, step.name, step.mode)
+        logger.info("%s: Writing data to duckdb...", step.name)
+        try:
+            self._save_to_db(result, step.name, step.mode)
+        except Exception as e:
+            logger.info("%s: Writing data to duckdb failed: %s", step.name, e)
+            raise
+        logger.info("%s: Data written to duckdb successfully.", step.name)
 
     def _execute_source_ddl_step(self, step: Step):
         """Run a no-result DDL statement against the *source* database (one statement per file).
@@ -246,7 +311,7 @@ class PipelineClass:
             return
 
         row_count = len(result.rows)
-        logging.info(f"Query for step '{step_name}' returned {row_count} rows.")
+        logging.debug(f"Query for step '{step_name}' returned {row_count} rows.")
 
         with connect_to_profiler_db(self._db_path) as conn:
             # Note: step_name is validated to be SQL-safe by Step.__post_init__
@@ -279,7 +344,7 @@ class PipelineClass:
 
             # Explicit commit before context exit
             conn.commit()
-            logging.info(f"Successfully processed {row_count} rows for table '{step_name}'.")
+            logging.debug(f"Successfully processed {row_count} rows for table '{step_name}'.")
 
     @staticmethod
     def _table_exists(conn: duckdb.DuckDBPyConnection, table_name: str) -> bool:

--- a/src/databricks/labs/lakebridge/assessments/pipeline.py
+++ b/src/databricks/labs/lakebridge/assessments/pipeline.py
@@ -14,7 +14,11 @@ from databricks.labs.blueprint.paths import read_text
 from databricks.labs.lakebridge import __version__ as lakebridge_version
 from databricks.labs.lakebridge.assessments.profiler_config import PipelineConfig, Step
 from databricks.labs.lakebridge.connections.database_manager import DatabaseConnector, FetchResult
-from databricks.labs.lakebridge.resources.assessments.common.duckdb_helpers import connect_to_profiler_db
+from databricks.labs.lakebridge.resources.assessments.common.duckdb_helpers import (
+    SaveMode,
+    connect_to_profiler_db,
+    save_to_duckdb,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -126,8 +130,18 @@ class PipelineClass:
             raise RuntimeError("Database executor is not set.")
 
         logging.info(f"Executing query: {query}")
+        if hasattr(self.executor, "stream"):
+            first = True
+            for df in self.executor.stream(query):
+                if df.empty:
+                    continue
+                write_mode: SaveMode = "overwrite" if first and step.mode == "overwrite" else "append"
+                save_to_duckdb(df, step.name, str(self._db_path), mode=write_mode)
+                first = False
+            return
+
         result = self.executor.fetch(query)
-        self._save_to_db(result, step.name, str(step.mode))
+        self._save_to_db(result, step.name, step.mode)
 
     def _execute_source_ddl_step(self, step: Step):
         """Run a no-result DDL statement against the *source* database (one statement per file).

--- a/src/databricks/labs/lakebridge/connections/database_manager.py
+++ b/src/databricks/labs/lakebridge/connections/database_manager.py
@@ -3,19 +3,21 @@ import dataclasses
 import importlib
 import logging
 from abc import abstractmethod
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterator, Sequence
 from types import TracebackType
 from typing import Any
 
 import pandas as pd
 
 from sqlalchemy import create_engine
-from sqlalchemy.engine import Engine, URL
+from sqlalchemy.engine import CursorResult, Engine, URL
 from sqlalchemy import text
 from sqlalchemy.exc import DBAPIError
 from sqlalchemy.orm.session import Session
 import mssql_python
 import redshift_connector  # type: ignore[import-untyped]
+from snowflake.connector.errors import Error as SnowflakeError
+from snowflake.connector.errors import NotSupportedError as SnowflakeNotSupportedError
 
 from databricks.labs.blueprint.installation import JsonObject
 from databricks.labs.lakebridge.connections.mssql_auth import resolve_mssql_credentials
@@ -124,6 +126,24 @@ class SnowflakeConnector(_BaseConnector):
             query={"warehouse": warehouse, "role": role},
         )
         return create_engine(snowflake_url)
+
+    def stream(self, query: str) -> Iterator[pd.DataFrame]:
+        if not self.engine:
+            raise ConnectionError("Not connected to the database.")
+
+        with Session(self.engine) as session, session.begin():
+            try:
+                result = session.execute(text(query))
+                if not isinstance(result, CursorResult):
+                    return
+                cursor = result.cursor
+                if cursor is None:
+                    return
+                yield from cursor.fetch_pandas_batches()
+            except (DBAPIError, SnowflakeNotSupportedError, SnowflakeError) as e:
+                logger.debug("Database query failed", exc_info=True)
+                reason = str(getattr(e, "orig", e)).split("\n", 1)[0].strip()
+                raise ConnectionError(f"Database query failed: {reason}") from e
 
 
 # In the mssql credential's ``database`` field, this sentinel (or a blank/whitespace value) means "no

--- a/src/databricks/labs/lakebridge/connections/database_manager.py
+++ b/src/databricks/labs/lakebridge/connections/database_manager.py
@@ -43,9 +43,29 @@ class FetchResult:
         return pd.DataFrame.from_records(self.rows, columns=list(self.columns))
 
 
+@dataclasses.dataclass
+class StreamResult:
+    """Chunked query results after warehouse execution has finished.
+
+    ``total_chunks`` is known once Snowflake returns result metadata.
+    ``batches`` must be fully consumed (or :meth:`close` called) so the
+    underlying DB session is released.
+    """
+
+    total_chunks: int
+    batches: Iterator[pd.DataFrame]
+    _close: Callable[[], None] = dataclasses.field(default=lambda: None, repr=False, compare=False)
+    _closed: bool = dataclasses.field(default=False, repr=False, compare=False)
+
+    def close(self) -> None:
+        if not self._closed:
+            self._closed = True
+            self._close()
+
+
 class DatabaseConnector(contextlib.AbstractContextManager):
     @abstractmethod
-    def fetch(self, query: str) -> FetchResult: ...
+    def fetch(self, query: str, *, on_executed: Callable[[], None] | None = None) -> FetchResult: ...
 
     @abstractmethod
     def close(self) -> None:
@@ -75,13 +95,15 @@ class _BaseConnector(DatabaseConnector):
     def close(self) -> None:
         self.engine.dispose()
 
-    def fetch(self, query: str) -> FetchResult:
+    def fetch(self, query: str, *, on_executed: Callable[[], None] | None = None) -> FetchResult:
         if not self.engine:
             raise ConnectionError("Not connected to the database.")
 
         with Session(self.engine) as session, session.begin():
             try:
                 result = session.execute(text(query))
+                if on_executed is not None:
+                    on_executed()
                 return FetchResult(list(result.keys()), result.fetchall())
             except DBAPIError as e:
                 logger.debug("Database query failed", exc_info=True)
@@ -92,6 +114,10 @@ class _BaseConnector(DatabaseConnector):
         query = "SELECT 101 AS test_column"
         result = self.fetch(query)
         return result.rows[0][0] == 101
+
+
+def _connection_error_reason(exc: BaseException) -> str:
+    return str(getattr(exc, "orig", exc)).split("\n", 1)[0].strip()
 
 
 class SnowflakeConnector(_BaseConnector):
@@ -127,23 +153,48 @@ class SnowflakeConnector(_BaseConnector):
         )
         return create_engine(snowflake_url)
 
-    def stream(self, query: str) -> Iterator[pd.DataFrame]:
+    def stream(self, query: str) -> StreamResult:
+        """Execute ``query`` and return chunked pandas batches.
+
+        Warehouse execution finishes before this method returns; callers can log
+        query-complete then iterate :attr:`StreamResult.batches` for download/write.
+        The returned result must be closed (consuming batches does this) so the
+        SQLAlchemy session is released.
+        """
         if not self.engine:
             raise ConnectionError("Not connected to the database.")
 
-        with Session(self.engine) as session, session.begin():
-            try:
-                result = session.execute(text(query))
-                if not isinstance(result, CursorResult):
-                    return
-                cursor = result.cursor
-                if cursor is None:
-                    return
-                yield from cursor.fetch_pandas_batches()
-            except (DBAPIError, SnowflakeNotSupportedError, SnowflakeError) as e:
-                logger.debug("Database query failed", exc_info=True)
-                reason = str(getattr(e, "orig", e)).split("\n", 1)[0].strip()
-                raise ConnectionError(f"Database query failed: {reason}") from e
+        stack = contextlib.ExitStack()
+        try:
+            session = stack.enter_context(Session(self.engine))
+            stack.enter_context(session.begin())
+            result = session.execute(text(query))
+            if not isinstance(result, CursorResult) or result.cursor is None:
+                stack.close()
+                return StreamResult(total_chunks=0, batches=iter(()))
+
+            cursor = result.cursor
+            result_set = getattr(cursor, "_result_set", None)
+            total_chunks = len(result_set.batches) if result_set is not None else 0
+            batch_iter = cursor.fetch_pandas_batches()
+
+            def _batches() -> Iterator[pd.DataFrame]:
+                try:
+                    yield from batch_iter
+                except (DBAPIError, SnowflakeNotSupportedError, SnowflakeError) as e:
+                    logger.debug("Database query failed", exc_info=True)
+                    raise ConnectionError(f"Database query failed: {_connection_error_reason(e)}") from e
+                finally:
+                    stack.close()
+
+            return StreamResult(total_chunks=total_chunks, batches=_batches(), _close=stack.close)
+        except (DBAPIError, SnowflakeNotSupportedError, SnowflakeError) as e:
+            stack.close()
+            logger.debug("Database query failed", exc_info=True)
+            raise ConnectionError(f"Database query failed: {_connection_error_reason(e)}") from e
+        except Exception:
+            stack.close()
+            raise
 
 
 # In the mssql credential's ``database`` field, this sentinel (or a blank/whitespace value) means "no
@@ -185,10 +236,12 @@ class MSSQLConnector(DatabaseConnector):
         except mssql_python.Error as e:
             raise ConnectionError(f"Failed to connect to {server}: {e}") from e
 
-    def fetch(self, query: str) -> FetchResult:
+    def fetch(self, query: str, *, on_executed: Callable[[], None] | None = None) -> FetchResult:
         cursor = self._conn.cursor()
         try:
             cursor.execute(query)
+            if on_executed is not None:
+                on_executed()
             if cursor.description is None:
                 return FetchResult([], [])
             names = [desc[0] for desc in cursor.description]
@@ -285,10 +338,12 @@ class RedshiftConnector(DatabaseConnector):
             )
         raise ConnectionError(f"Invalid Redshift auth_type: {auth_type}. Expected one of: sql_authentication, iam")
 
-    def fetch(self, query: str) -> FetchResult:
+    def fetch(self, query: str, *, on_executed: Callable[[], None] | None = None) -> FetchResult:
         cursor = self._conn.cursor()
         try:
             cursor.execute(query)
+            if on_executed is not None:
+                on_executed()
             # DDL (e.g. DROP, CREATE VIEW) has no result set; return empty result
             if cursor.description is None:
                 return FetchResult([], [])

--- a/src/databricks/labs/lakebridge/resources/assessments/common/duckdb_helpers.py
+++ b/src/databricks/labs/lakebridge/resources/assessments/common/duckdb_helpers.py
@@ -68,7 +68,7 @@ def save_to_duckdb(
                 _save_append(conn, df, table_name, schema)
             else:
                 raise ValueError(f"Unsupported mode '{mode}'. Must be 'overwrite' or 'append'.")
-            logger.info("Wrote %d rows to '%s' (mode=%s).", len(df), table_name, mode)
+            logger.debug("Wrote %d rows to '%s' (mode=%s).", len(df), table_name, mode)
     except Exception as e:
         logger.error("Error in save_to_duckdb for table '%s': %s", table_name, str(e))
         raise


### PR DESCRIPTION
### Summary

Adds phase logging so profiler `sql` steps have better visibility during long runs. 

Stacks onto #2610.

### Phases

| Phase | `stream` | `fetch` |
| ----- | ------------------ | ---------------------- |
| Submit | `Submitting query to source.` | same |
| Execute | `Query execution completed successfully.` / `Query execution failed: {reason}.` | same |
| Fetch / write | `Fetching and writing results ({i}/{N}).` (per chunk; no separate DuckDB line) | `Fetching results.` then `Writing data to duckdb...` / `Data written to duckdb successfully.` |

Full SQL text is demoted to DEBUG so large extracts (e.g. `query_history`) do not drown the phase logs.