### PR TITLE
analyzer: fix validation of the source path

### DIFF
--- a/src/databricks/labs/lakebridge/analyzer/lakebridge_analyzer.py
+++ b/src/databricks/labs/lakebridge/analyzer/lakebridge_analyzer.py
@@ -9,7 +9,7 @@ from databricks.labs.blueprint.tui import Prompts
 
 from databricks.labs.bladespector.analyzer import Analyzer
 
-from databricks.labs.lakebridge.helpers.file_utils import check_path
+from databricks.labs.lakebridge.helpers.file_utils import check_writable_path, check_readable_path
 
 logger = get_logger(__file__)
 
@@ -31,7 +31,7 @@ class AnalyzerPrompts:
         directory_str = self._prompts.question(
             "Enter the path of the directory containing sources to analyze",
             default=Path.cwd().as_posix(),
-            validate=check_path,
+            validate=check_readable_path,
         )
         return Path(directory_str)
 
@@ -40,7 +40,7 @@ class AnalyzerPrompts:
         filename = self._prompts.question(
             "Enter the path of the report file for analyzer results",
             default="lakebridge-analyzer-results.xlsx",
-            validate=check_path,
+            validate=check_writable_path,
         )
         return Path(filename)
 
@@ -74,9 +74,9 @@ class AnalyzerRunner:
             results_file_path = results_file_path.resolve()
             logger.debug(f"Relative path provided for results file, will use: {results_file_path}")
 
-        if not check_path(source_dir):
-            raise ValueError(f"Invalid source directory, not writable: {source_dir}")
-        if not check_path(results_file_path):
+        if not check_readable_path(source_dir):
+            raise ValueError(f"Invalid source directory, cannot read: {source_dir}")
+        if not check_writable_path(results_file_path):
             raise ValueError(f"Invalid result path, not writable: {results_file_path}")
 
         json_result = results_file_path.with_suffix(".json") if generate_json else None

--- a/src/databricks/labs/lakebridge/helpers/file_utils.py
+++ b/src/databricks/labs/lakebridge/helpers/file_utils.py
@@ -68,7 +68,7 @@ def chdir(new_path: Path) -> Generator[None]:
         os.chdir(saved_path)
 
 
-def check_path(path: Path | str) -> bool:
+def check_writable_path(path: Path | str) -> bool:
     """Validates a path for both existing files and writable files."""
     try:
         path_obj = Path(path) if not isinstance(path, Path) else path
@@ -78,6 +78,17 @@ def check_path(path: Path | str) -> bool:
 
         parent = path_obj.parent
         return parent.exists() and os.access(parent, os.W_OK)
+
+    except OSError as e:
+        logger.warning(f"Could not validate path: {path}, error: {e}")
+        return False
+
+
+def check_readable_path(path: Path | str) -> bool:
+    """Validates a path exists and can be read."""
+    try:
+        path_obj = Path(path) if not isinstance(path, Path) else path
+        return path_obj.exists() and os.access(path_obj, os.R_OK)
 
     except OSError as e:
         logger.warning(f"Could not validate path: {path}, error: {e}")

--- a/tests/unit/analyzer/test_analyzer.py
+++ b/tests/unit/analyzer/test_analyzer.py
@@ -32,6 +32,7 @@ def test_analyze_arguments_return(tmp_path: Path, report_file: Path) -> None:
     path = tmp_path / "in"
     file = tmp_path / report_file
     mock_prompts = MockPrompts({})
+    path.mkdir()
 
     runner = AnalyzerRunner(runnable=_mock_analyze, is_debug=True)
     expected_result = AnalyzerResult(source_directory=path, report_path=file, source_system=str("Synapse"))
@@ -46,6 +47,7 @@ def test_analyze_prompts_result(tmp_path: Path):
     first_tech = next(iter(sorted(Analyzer.supported_source_technologies(), key=str.casefold)))
     input_path = tmp_path / "in"
     report_file = tmp_path / "report.xlsx"
+    input_path.mkdir()
     mock_prompts = MockPrompts(
         {
             "Select the source technology": "0",
@@ -61,6 +63,7 @@ def test_analyze_prompt_relative_result_path(tmp_path: Path) -> None:
     """Verify the handling when a relative path is provided for the report file."""
     first_tech = next(iter(sorted(Analyzer.supported_source_technologies(), key=str.casefold)))
     input_path = Path("in")
+    (tmp_path / input_path).mkdir()
     report_file = Path("report.xlsx")
     mock_prompts = MockPrompts(
         {


### PR DESCRIPTION
## Changes

### What does this PR do?

This PR updates the checks we do for the source directory when analysing, it only needs to be readable instead of writable.

At one point the output was written into the source directory, which meant it needed to be writable. However since the analyzer was updated to allow the output location to be specified this has not been necessary.

### Functionality

- modified existing command: `databricks labs lakebridge analyze`

### Tests

- manually tested
- existing unit tests (needed updating)
- existing integration tests
