### PR TITLE
Reorder Teradata profiler config prompts to match other connectors

### DIFF
--- a/src/databricks/labs/lakebridge/assessments/configure_assessment.py
+++ b/src/databricks/labs/lakebridge/assessments/configure_assessment.py
@@ -422,6 +422,13 @@ class ConfigureTeradataAssessment(AssessmentConfigurator):
         secret_vault_type = str(self.prompts.choice("Enter secret vault type (local | env)", ["local", "env"])).lower()
         secret_vault_name = None
 
+        # Prompt for the connection fields in their natural order (host, port, database, user,
+        # password) so the flow matches the other configurators (e.g. Oracle, Redshift). The
+        # password is read last because the `env` vault stores an env-var name, not the secret.
+        host = self.prompts.question("Enter the Teradata server or host details")
+        port = int(self.prompts.question("Enter the port details", valid_number=True, default="1025"))
+        database = self.prompts.question("Enter the default database name", default="DBC")
+        user = self.prompts.question("Enter the user details")
         if secret_vault_type == "env":
             password = self.prompts.question("Enter the environment variable name holding the password")
         else:
@@ -431,11 +438,11 @@ class ConfigureTeradataAssessment(AssessmentConfigurator):
             "secret_vault_type": secret_vault_type,
             "secret_vault_name": secret_vault_name,
             source: {
-                "host": self.prompts.question("Enter the Teradata server or host details"),
-                "port": int(self.prompts.question("Enter the port details", valid_number=True, default="1025")),
-                "user": self.prompts.question("Enter the user details"),
+                "host": host,
+                "port": port,
+                "user": user,
                 "password": password,
-                "database": self.prompts.question("Enter the default database name", default="DBC"),
+                "database": database,
             },
         }
 


### PR DESCRIPTION
The Teradata configurator prompted for the password before host, port, user and database, because the password was read into a local variable ahead of the credential dict literal. This made it look like host/user were never asked when the flow paused at the password prompt.

Prompt for the connection fields first (host, port, database, user, password), matching the Oracle and Redshift configurators. The password is still read last since the env vault stores an env-var name.

<!-- REMOVE IRRELEVANT COMMENTS BEFORE CREATING A PULL REQUEST -->
## Changes
<!-- Summary of your changes that are easy to understand. Add screenshots when necessary, they're helpful to illustrate the before and after state -->
### What does this PR do?

### Relevant implementation details

### Caveats/things to watch out for when reviewing:

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #..

### Functionality

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs lakebridge ...`
- [ ] ... +add your own

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
