### PR TITLE
docs: fix Supported Sources — Analyzer does not support Scala

### DIFF
--- a/docs/lakebridge/docs/overview.mdx
+++ b/docs/lakebridge/docs/overview.mdx
@@ -313,7 +313,7 @@ Supported sources
     <tr>
       <td>scala</td>
       <td></td>
-      <td>&#x2705;</td>
+      <td></td>
       <td>&#x2705;</td>
       <td></td>
     </tr>


### PR DESCRIPTION
## What & why

The **Supported sources** table on the Overview page marks `scala` as supported under **Assessment · Analyzer**. The Analyzer does not support Scala — its engine (bladespector) has no Scala source technology, so `analyze --source-tech` offers no Scala option.

Scala is supported only by the **Switch** LLM transpiler (Scala → Databricks Python notebook). This is already stated elsewhere in the docs:

- `faq.mdx`: *"Other: Airflow, Python, Scala (via Switch)"*
- `transpile/pluggable_transpilers/switch/index.mdx`: *"`scala` | Scala Code → Databricks Python Notebook"*

So the `Converter` check on the `scala` row is correct; only the `Assessment · Analyzer` check is wrong.

## Change

Clear the erroneous **Assessment · Analyzer** check on the `scala` row of the Supported sources table. The `Converter` check is left unchanged.

```diff
       <td>scala</td>
       <td></td>
-      <td>&#x2705;</td>   <!-- Assessment - Analyzer -->
+      <td></td>
       <td>&#x2705;</td>   <!-- Converter (Switch) — unchanged -->
       <td></td>
```

## Note

The `python` row appears to have the same issue (marked under Assessment · Analyzer, but Analyzer has no bare-`python` dialect — only `PySpark`/`Jupyter Notebook`). Left out of this PR to keep it focused; happy to include it if maintainers prefer.
